### PR TITLE
Remember me for OpenID

### DIFF
--- a/admin-ui/src/pages/LoginSuccess.tsx
+++ b/admin-ui/src/pages/LoginSuccess.tsx
@@ -43,6 +43,9 @@ class LoginSuccess extends React.Component<Props, State> {
             refreshToken: res.json.refreshToken,
             accessTokenExpiry: new Date(new Date().getTime() + Ajax.ACCESS_TOKEN_EXPIRY_OFFSET)
           };
+          if (res.json.longLived) {
+            Ajax.PERSISTER.persistRefreshTokenInLocalStorage(Ajax.CREDENTIALS);
+          }
           Ajax.PERSISTER.updateCredentialsSessionStorage(Ajax.CREDENTIALS).then(() => {
             this.setState({
               redirect: "/dashboard"

--- a/booking-ui/src/pages/LoginSuccess.tsx
+++ b/booking-ui/src/pages/LoginSuccess.tsx
@@ -34,7 +34,6 @@ class LoginSuccess extends React.Component<Props, State> {
     if (this.props.params.id) {
       return Ajax.get("/auth/verify/" + this.props.params.id).then(res => {
         if (res.json && res.json.accessToken) {
-          alert(res.json);
           Ajax.CREDENTIALS = {
             accessToken: res.json.accessToken,
             refreshToken: res.json.refreshToken,

--- a/booking-ui/src/pages/LoginSuccess.tsx
+++ b/booking-ui/src/pages/LoginSuccess.tsx
@@ -34,11 +34,15 @@ class LoginSuccess extends React.Component<Props, State> {
     if (this.props.params.id) {
       return Ajax.get("/auth/verify/" + this.props.params.id).then(res => {
         if (res.json && res.json.accessToken) {
+          alert(res.json);
           Ajax.CREDENTIALS = {
             accessToken: res.json.accessToken,
             refreshToken: res.json.refreshToken,
             accessTokenExpiry: new Date(new Date().getTime() + Ajax.ACCESS_TOKEN_EXPIRY_OFFSET)
           };
+          if (res.json.longLived) {
+            Ajax.PERSISTER.persistRefreshTokenInLocalStorage(Ajax.CREDENTIALS);
+          }
           Ajax.PERSISTER.updateCredentialsSessionStorage(Ajax.CREDENTIALS).then(() => {
             RuntimeConfig.setLoginDetails(this.context).then(() => {
               this.setState({

--- a/server/auth-router.go
+++ b/server/auth-router.go
@@ -18,6 +18,7 @@ import (
 type JWTResponse struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`
+	LongLived    bool   `json:"longLived"`
 }
 
 type Claims struct {
@@ -292,6 +293,7 @@ func (router *AuthRouter) verify(w http.ResponseWriter, r *http.Request) {
 	res := &JWTResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		LongLived:    payload.LongLived,
 	}
 	SendJSON(w, res)
 }


### PR DESCRIPTION
Hey!

Using OpenID the RememberMe functionality is not working.
This enables the long-lived Token in Local Storage.

Another idea would be to just remember the Username and Auth-Provider and to directly jump to auth provider, so livetime can be controlled there. Maybe the better idea.
What do you think?
