### PR TITLE
BugFix 24:00 - 23:59 for English language

### DIFF
--- a/commons/ts/src/util/Formatting.ts
+++ b/commons/ts/src/util/Formatting.ts
@@ -5,11 +5,13 @@ export default class Formatting {
             "today": "Heute",
             "tomorrow": "Morgen",
             "inXdays": "In {{x}} Tagen",
+            "hour12": false,
         },
         "en": {
             "today": "Today",
             "tomorrow": "Tomorrow",
             "inXdays": "In {{x}} days",
+            "hour12": true,
         },
     };
 
@@ -25,6 +27,11 @@ export default class Formatting {
         }
         return res;
     }
+    
+    static tbool(s: string) {
+        let res: boolean = Formatting.I18n[Formatting.Language][s];
+        return res;
+    }
 
     static getFormatter(local?: boolean): Intl.DateTimeFormat {
         let formatter = new Intl.DateTimeFormat(Formatting.Language, {
@@ -35,7 +42,7 @@ export default class Formatting {
             day: '2-digit',
             hour: 'numeric',
             minute: 'numeric',
-            hour12: false
+            hour12: this.tbool("hour12")
           });
         return formatter;
     }


### PR DESCRIPTION
Hey!

Another one: Having language set to English a booking entry at /ui/bookings with whole-day booking looked as followed:

->  Tuesday, 06/28/2022, **24:00** 
<-  Tuesday, 06/28/2022, 23:59

Reason:

Setting hour12 to false and language to 'en' in Intl.DateTimeFormat() at Formatting.ts resulted in output "24:00" instead of expected "00:00"

So i've changed hour12 to true for english.

Output is now
->  Tuesday, 06/28/2022, **12:00 AM** 
<-  Tuesday, 06/28/2022, **11:59 PM** 



Kind Regards

Folke
