### PR TITLE
Feature: booking-ui: Complete Map scrollable

### DIFF
--- a/booking-ui/src/pages/Search.css
+++ b/booking-ui/src/pages/Search.css
@@ -177,6 +177,9 @@
 
 @media only screen and (max-width: 600px), only screen and (max-height: 500px) {
     .space-list {
+        padding-bottom: 250px;
+    }
+    .space-list.maximized {
         padding-bottom: 130px;
     }
 
@@ -186,6 +189,9 @@
         padding-top: 70px;
         padding-left: 10px;
         padding-right: 10px;
+        padding-bottom: 250px;
+    }
+    .container-map.maximized {
         padding-bottom: 130px;
     }
 

--- a/booking-ui/src/pages/Search.tsx
+++ b/booking-ui/src/pages/Search.tsx
@@ -488,6 +488,11 @@ class Search extends React.Component<Props, State> {
   toggleSearchContainer = () => {
     const ref = this.searchContainerRef.current;
     ref.classList.toggle("minimized");
+    
+    const map = document.querySelector('.container-map');
+    if (map) map.classList.toggle("maximized");
+    const list = document.querySelector('.space-list');
+    if (list) list.classList.toggle("maximized");
   }
 
   toggleListView = () => {


### PR DESCRIPTION
Feature: booking-ui: Complete Map scrollable even if searchbox is not minimized.

i ofen have to close searchbox to see reservations at the bottom of the map. 
Then i want to check another floor, have to open searchbox again, switch floor, and close searchbox again.

this fix makes searching the floors more convenien