### PR TITLE
Fix: clear sessionstorage on invalid AccessToken

### DIFF
--- a/commons/ts/src/util/Ajax.ts
+++ b/commons/ts/src/util/Ajax.ts
@@ -104,8 +104,12 @@ export default class Ajax {
                 reject(new AjaxError(response.status, 0));
               });
             } else {
-              release();
-              reject(new AjaxError(response.status, 0));
+              // token invalid
+              Ajax.CREDENTIALS = new AjaxCredentials();
+              Ajax.PERSISTER.deleteCredentialsFromSessionStorage().then(() => {
+                resolve(Ajax.CREDENTIALS);
+                release();
+              });
             }
           }).catch(err => {
             release();


### PR DESCRIPTION
We're using AzureAD-OpenID and sometimes the refresh token in persistent local storage gets invalid.
In this case seatsurfing is not usable unless you clear manually all session-storage which is a pain for us admins.

This fix clears local storage if refreshtoken is invalid and login is displayed.

Can be tested by changing refreshtoken in developer tools to some crap and then reopen browser.

Old bug:
![image](https://user-images.githubusercontent.com/3075214/196054682-32e0d980-0c8a-4ab4-beec-b30996e7511c.png)
