### PR TITLE
Buddies feature

### DIFF
--- a/booking-ui/public/locales/de/common.json
+++ b/booking-ui/public/locales/de/common.json
@@ -101,5 +101,10 @@
     "tomorrow": "Morgen",
     "inXdays": "In {{x}} Tagen",
     "hour12": "0",
-    "passwordChange": "Kennwort ändern"
+    "passwordChange": "Kennwort ändern",
+    "removeBuddy": "Kumpel entfernen",
+    "addBuddy": "Freund hinzufügen",
+    "confirmRemoveBuddy": "Sind Sie sicher, dass Sie Buddy entfernen möchten?",
+    "myBuddies": "Meine Kumpel",
+    "noBuddies": "Keine Freunde"
 }

--- a/booking-ui/public/locales/en/common.json
+++ b/booking-ui/public/locales/en/common.json
@@ -101,5 +101,10 @@
     "tomorrow": "Tomorrow",
     "inXdays": "In {{x}} days",
     "hour12": "1",
-    "passwordChange": "Change password"
+    "passwordChange": "Change password",
+    "removeBuddy": "Remove buddy",
+    "addBuddy": "Add buddy",
+    "confirmRemoveBuddy": "Are you sure you want to remove buddy?",
+    "myBuddies": "My buddies",
+    "noBuddies": "No buddies"
 }

--- a/booking-ui/public/locales/fr/common.json
+++ b/booking-ui/public/locales/fr/common.json
@@ -101,5 +101,10 @@
     "tomorrow": "Demain",
     "inXdays": "Dans {{x}} de jours",
     "hour12": "0",
-    "passwordChange": "Modifier le mot de passe"
+    "passwordChange": "Modifier le mot de passe",
+    "removeBuddy": "Supprimer un ami",
+    "addBuddy": "Ajouter un ami",
+    "confirmRemoveBuddy": "Êtes-vous sûr de vouloir supprimer un ami ?",
+    "myBuddies": "Mes potes",
+    "noBuddies": "Pas de copains"
 }

--- a/booking-ui/public/locales/it/common.json
+++ b/booking-ui/public/locales/it/common.json
@@ -101,5 +101,10 @@
     "tomorrow": "Domani",
     "inXdays": "Fra {{x}} giorni",
     "hour12": "0",
-    "passwordChange": "Cambia password"
+    "passwordChange": "Cambia password",
+    "removeBuddy": "Rimuovi amico",
+    "addBuddy": "Aggiungi amico",
+    "confirmRemoveBuddy": "Sei sicuro di voler rimuovere l'amico?",
+    "myBuddies": "I miei amici",
+    "noBuddies": "Nessun amico"
 }

--- a/booking-ui/src/components/NavBar.tsx
+++ b/booking-ui/src/components/NavBar.tsx
@@ -134,6 +134,7 @@ class NavBar extends React.Component<Props, State> {
         let initMergeButton = <></>;
         let mergeRequestsButton = <></>;
         let collapsable = <></>;
+        let buddies = <></>;
         
         if (!RuntimeConfig.EMBEDDED) {
             if (this.state.allowAdmin) {
@@ -149,11 +150,16 @@ class NavBar extends React.Component<Props, State> {
             }
         }
 
+        if (RuntimeConfig.INFOS.showNames) {
+            buddies = <Nav.Link as={Link} eventKey="/buddies" href="/buddies">{RuntimeConfig.EMBEDDED ? <IconCalendar className="feather feather-lg" /> : this.props.t("myBuddies")}</Nav.Link>
+        }
+
         collapsable = (
             <>
                 <Nav activeKey={this.props.router.pathname}>
                     <Nav.Link as={Link} eventKey="/search" href="/search">{RuntimeConfig.EMBEDDED ? <IconPlus className="feather feather-lg" /> : this.props.t("bookSeat")}</Nav.Link>
                     <Nav.Link as={Link} eventKey="/bookings" href="/bookings">{RuntimeConfig.EMBEDDED ? <IconCalendar className="feather feather-lg" /> : this.props.t("myBookings")}</Nav.Link>
+                    {buddies}
                     <Nav.Link as={Link} eventKey="/preferences" href="/preferences">{RuntimeConfig.EMBEDDED ? <IconSettings className="feather feather-lg" /> : this.props.t("preferences")}</Nav.Link>
                     {adminButton}
                     {signOffButton}

--- a/booking-ui/src/pages/buddies.tsx
+++ b/booking-ui/src/pages/buddies.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Ajax, Buddy } from 'flexspace-commons';
+import Loading from '../components/Loading';
+import { Button, Form, ListGroup, Modal } from 'react-bootstrap';
+import { WithTranslation, withTranslation } from 'next-i18next';
+import { NextRouter } from 'next/router';
+import NavBar from '@/components/NavBar';
+import withReadyRouter from '@/components/withReadyRouter';
+
+interface State {
+  loading: boolean
+  selectedItem: Buddy | null
+}
+
+interface Props extends WithTranslation {
+  router: NextRouter
+}
+
+class Buddies extends React.Component<Props, State> {
+  data: Buddy[];
+
+  constructor(props: any) {
+    super(props);
+    this.data = [];
+    this.state = {
+      loading: true,
+      selectedItem: null
+    };
+  }
+
+  componentDidMount = () => {
+    if (!Ajax.CREDENTIALS.accessToken) {
+      this.props.router.push("/login");
+      return;
+    }
+    this.loadData();
+  }
+
+  loadData = () => {
+    Buddy.list().then(list => {
+      this.data = list;
+      this.setState({ loading: false });
+    });
+  }
+
+  onItemPress = (item: Buddy) => {
+    this.setState({ selectedItem: item });
+  }
+
+  removeBuddy = (item: Buddy | null) => {
+    this.setState({
+      loading: true
+    });
+    this.state.selectedItem?.delete().then(() => {
+      this.setState({
+        selectedItem: null,
+      }, this.loadData);
+    });
+  }
+
+  renderItem = (item: Buddy) => {
+    return (
+      <ListGroup.Item key={item.id}>
+        <p>{item.buddy.email}</p>
+        <Button variant="danger" onClick={() => this.onItemPress(item)}>
+          {this.props.t("removeBuddy")}
+        </Button>
+      </ListGroup.Item>
+    );
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <Loading />;
+    }
+    if (this.data.length === 0) {
+      return (
+        <>
+          <NavBar />
+          <div className="container-signin">
+            <Form className="form-signin">
+              <p>{this.props.t("noBuddies")}</p>
+            </Form>
+          </div>
+        </>
+      );
+    }
+    return (
+      <>
+        <NavBar />
+        <div className="container-signin">
+          <Form className="form-signin">
+            <ListGroup>
+              {this.data.map(item => this.renderItem(item))}
+            </ListGroup>
+          </Form>
+        </div>
+        <Modal show={this.state.selectedItem != null} onHide={() => this.setState({ selectedItem: null })}>
+          <Modal.Header closeButton>
+            <Modal.Title>{this.props.t("removeBuddy")}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <p>{this.props.t("confirmRemoveBuddy", { interpolation: { escapeValue: false } })}</p>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => this.setState({ selectedItem: null })}>
+              {this.props.t("back")}
+            </Button>
+            <Button variant="danger" onClick={() => this.removeBuddy(this.state.selectedItem)}>
+              {this.props.t("removeBuddy")}
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </>
+    );
+  }
+}
+
+export default withTranslation()(withReadyRouter(Buddies as any));

--- a/booking-ui/src/styles/Search.css
+++ b/booking-ui/src/styles/Search.css
@@ -163,6 +163,10 @@
     background-color: rgba(184, 37, 222, 0.9) !important;
 }
 
+.space-buddy-desk {
+    background-color: rgba(36, 21, 197, 0.9) !important;
+}
+
 .space-list-item-content {
     text-overflow: ellipsis;
     overflow: hidden;

--- a/commons/ts/src/index.ts
+++ b/commons/ts/src/index.ts
@@ -7,6 +7,7 @@ export { default as JwtDecoder } from './util/JwtDecoder';
 export { Entity } from './types/Entity';
 export { default as AuthProvider } from './types/AuthProvider';
 export { default as Booking } from './types/Booking';
+export { default as Buddy } from './types/Buddy';
 export { default as Domain } from './types/Domain';
 export { default as Location } from './types/Location';
 export { default as Organization } from './types/Organization';

--- a/commons/ts/src/types/Buddy.ts
+++ b/commons/ts/src/types/Buddy.ts
@@ -1,0 +1,61 @@
+import { Entity } from "./Entity";
+import Ajax from "../util/Ajax";
+import User from "./User";
+
+export default class Buddy extends Entity {
+    buddy: User;
+
+    constructor() {
+        super();
+        this.buddy = new User();
+    }
+
+    serialize(): Object {
+        return Object.assign(super.serialize(), {
+            "buddyId": this.buddy.id,
+            "buddyEmail": this.buddy.email,
+        });
+    }
+
+    deserialize(input: any): void {
+        super.deserialize(input);
+        if (input.buddyId) {
+            this.buddy.id = input.buddyId;
+        }
+        if (input.buddyEmail) {
+            this.buddy.email = input.buddyEmail;
+        }
+    }
+
+    getBackendUrl(): string {
+        return "/buddy/";
+    }
+
+    async save(): Promise<Buddy> {
+        return Ajax.saveEntity(this, this.getBackendUrl()).then(() => this);
+    }
+
+    async delete(): Promise<void> {
+        return Ajax.delete(this.getBackendUrl() + this.id).then(() => undefined);
+    }
+
+    static async list(): Promise<Buddy[]> {
+        return Ajax.get("/buddy/").then(result => {
+            let list: Buddy[] = [];
+            (result.json as []).forEach(item => {
+                let e: Buddy = new Buddy();
+                e.deserialize(item);
+                list.push(e);
+            });
+            return list;
+        });
+    }
+
+    static createFromRawArray(arr: any[]): Buddy[] {
+        return arr.map(buddy => {
+            let res = new Buddy();
+            res.deserialize(buddy);
+            return res;
+        });
+    }
+}

--- a/server/app.go
+++ b/server/app.go
@@ -44,6 +44,7 @@ func (a *App) InitializeRouter() {
 	routers["/location/{locationId}/space/"] = &SpaceRouter{}
 	routers["/location/"] = &LocationRouter{}
 	routers["/booking/"] = &BookingRouter{}
+	routers["/buddy/"] = &BuddyRouter{}
 	routers["/organization/"] = &OrganizationRouter{}
 	routers["/auth-provider/"] = &AuthProviderRouter{}
 	routers["/auth/"] = &AuthRouter{}

--- a/server/buddy-repository.go
+++ b/server/buddy-repository.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"sync"
+)
+
+type BuddyRepository struct {
+}
+
+type Buddy struct {
+	ID      string
+	OwnerID string
+	BuddyID string
+}
+
+type BuddyDetails struct {
+	BuddyEmail string
+	Buddy
+}
+
+var buddyRepository *BuddyRepository
+var buddyRepositoryOnce sync.Once
+
+func GetBuddyRepository() *BuddyRepository {
+	buddyRepositoryOnce.Do(func() {
+		buddyRepository = &BuddyRepository{}
+		_, err := GetDatabase().DB().Exec("CREATE TABLE IF NOT EXISTS buddies (" +
+			"id uuid DEFAULT uuid_generate_v4(), " +
+			"owner_id uuid NOT NULL, " +
+			"buddy_id uuid NOT NULL, " +
+			"PRIMARY KEY (id))")
+		if err != nil {
+			panic(err)
+		}
+		_, err = GetDatabase().DB().Exec("CREATE INDEX IF NOT EXISTS idx_buddies_owner_id ON buddies(owner_id)")
+		if err != nil {
+			panic(err)
+		}
+	})
+	return buddyRepository
+}
+
+func (r *BuddyRepository) RunSchemaUpgrade(curVersion, targetVersion int) {
+	// No updates yet
+}
+
+func (r *BuddyRepository) Create(e *Buddy) error {
+	var id string
+	err := GetDatabase().DB().QueryRow("INSERT INTO buddies "+
+		"(owner_id, buddy_id) "+
+		"VALUES ($1, $2) "+
+		"RETURNING id",
+		e.OwnerID, e.BuddyID).Scan(&id)
+	if err != nil {
+		return err
+	}
+	e.ID = id
+	return nil
+}
+
+func (r *BuddyRepository) GetOne(id string) (*BuddyDetails, error) {
+	e := &BuddyDetails{}
+	err := GetDatabase().DB().QueryRow("SELECT buddies.id, buddies.owner_id, buddies.buddy_id, "+
+		"users.email "+
+		"FROM buddies "+
+		"INNER JOIN users ON buddies.buddy_id = users.id "+
+		"WHERE buddies.id = $1",
+		id).Scan(&e.ID, &e.OwnerID, &e.BuddyID, &e.BuddyEmail)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func (r *BuddyRepository) GetAllByOwner(ownerID string) ([]*BuddyDetails, error) {
+	var result []*BuddyDetails
+	rows, err := GetDatabase().DB().Query("SELECT buddies.id, buddies.owner_id, buddies.buddy_id, "+
+		"users.email "+
+		"FROM buddies "+
+		"INNER JOIN users ON buddies.buddy_id = users.id "+
+		"WHERE owner_id = $1 "+
+		"ORDER BY id DESC", ownerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		e := &BuddyDetails{}
+		err = rows.Scan(&e.ID, &e.OwnerID, &e.BuddyID, &e.BuddyEmail)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, e)
+	}
+	return result, nil
+}
+
+func (r *BuddyRepository) Delete(e *BuddyDetails) error {
+	_, err := GetDatabase().DB().Exec("DELETE FROM buddies WHERE id = $1", e.ID)
+	return err
+}

--- a/server/buddy-router.go
+++ b/server/buddy-router.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type BuddyRouter struct {
+}
+
+type BuddyRequest struct {
+	BuddyID    string `json:"buddyId" validate:"required"`
+	BuddyEmail string `json:"buddyEmail"`
+}
+
+type CreateBuddyRequest struct {
+	BuddyRequest
+}
+
+type GetBuddyResponse struct {
+	ID string `json:"id"`
+	CreateBuddyRequest
+}
+
+func (router *BuddyRouter) setupRoutes(s *mux.Router) {
+	s.HandleFunc("/{id}", router.delete).Methods("DELETE")
+	s.HandleFunc("/", router.create).Methods("POST")
+	s.HandleFunc("/", router.getAll).Methods("GET")
+}
+
+func (router *BuddyRouter) getAll(w http.ResponseWriter, r *http.Request) {
+	list, err := GetBuddyRepository().GetAllByOwner(GetRequestUserID(r))
+	if err != nil {
+		log.Println(err)
+		SendInternalServerError(w)
+		return
+	}
+	res := []*GetBuddyResponse{}
+	for _, e := range list {
+		m := router.copyToRestModel(e)
+		res = append(res, m)
+	}
+	SendJSON(w, res)
+}
+
+func (router *BuddyRouter) delete(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	e, err := GetBuddyRepository().GetOne(vars["id"])
+	if err != nil {
+		SendNotFound(w)
+		return
+	}
+	if e.OwnerID != GetRequestUserID(r) {
+		SendForbidden(w)
+	}
+	if err := GetBuddyRepository().Delete(e); err != nil {
+		SendInternalServerError(w)
+		return
+	}
+	SendUpdated(w)
+}
+
+func (router *BuddyRouter) create(w http.ResponseWriter, r *http.Request) {
+	var m CreateBuddyRequest
+	if UnmarshalValidateBody(r, &m) != nil {
+		SendBadRequest(w)
+		return
+	}
+
+	buddyUser, err := GetUserRepository().GetOne(m.BuddyID)
+	if err != nil {
+		SendBadRequest(w)
+		return
+	}
+
+	e := &Buddy{}
+	e.BuddyID = buddyUser.ID
+	e.OwnerID = GetRequestUserID(r)
+	if err := GetBuddyRepository().Create(e); err != nil {
+		log.Println(err)
+		SendInternalServerError(w)
+		return
+	}
+	SendCreated(w, e.ID)
+}
+
+func (router *BuddyRouter) copyToRestModel(e *BuddyDetails) *GetBuddyResponse {
+	m := &GetBuddyResponse{}
+	m.ID = e.ID
+	m.BuddyID = e.BuddyID
+	m.BuddyEmail = e.BuddyEmail
+	return m
+}

--- a/server/buddy-router_test.go
+++ b/server/buddy-router_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestBuddiesEmptyResult(t *testing.T) {
+	clearTestDB()
+	loginResponse := createLoginTestUser()
+
+	req := newHTTPRequest("GET", "/buddy/", loginResponse.UserID, nil)
+	res := executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusOK, res.Code)
+	var resBody []string
+	json.Unmarshal(res.Body.Bytes(), &resBody)
+	if len(resBody) != 0 {
+		t.Fatalf("Expected empty array")
+	}
+}
+
+func TestBuddiesCRUD(t *testing.T) {
+	clearTestDB()
+	org := createTestOrg("test.com")
+	GetSettingsRepository().Set(org.ID, SettingMaxDaysInAdvance.Name, "5000")
+
+	// Create buddy users
+	buddyUser1 := createTestUserInOrg(org)
+
+	// Switch to non-admin user
+	user := createTestUserInOrg(org)
+	loginResponse := loginTestUser(user.ID)
+
+	// 1. Create
+	payload := "{\"buddyId\": \"" + buddyUser1.ID + "\"}"
+	req := newHTTPRequest("POST", "/buddy/", loginResponse.UserID, bytes.NewBufferString(payload))
+	res := executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusCreated, res.Code)
+	id := res.Header().Get("X-Object-Id")
+
+	// 2. Read all buddies and ensure buddy was created correctly
+	req = newHTTPRequest("GET", "/buddy/", loginResponse.UserID, nil)
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusOK, res.Code)
+	var resBody []*GetBuddyResponse
+	json.Unmarshal(res.Body.Bytes(), &resBody)
+	if len(resBody) != 1 {
+		t.Fatalf("Expected array with 1 element")
+	}
+	checkTestString(t, buddyUser1.ID, resBody[0].BuddyID)
+	checkTestString(t, id, resBody[0].ID)
+
+	// 3. Delete
+	req = newHTTPRequest("DELETE", "/buddy/"+id, loginResponse.UserID, nil)
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusNoContent, res.Code)
+
+	// 4. Read all buddies and ensure buddy was removed correctly
+	req = newHTTPRequest("GET", "/buddy/", loginResponse.UserID, nil)
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusOK, res.Code)
+	var resBody2 []*GetBuddyResponse
+	json.Unmarshal(res.Body.Bytes(), &resBody2)
+	if len(resBody2) != 0 {
+		t.Fatalf("Expected empty array")
+	}
+}
+
+func TestDeleteBuddyOfAnotherUser(t *testing.T) {
+	clearTestDB()
+	org := createTestOrg("test.com")
+	GetSettingsRepository().Set(org.ID, SettingMaxDaysInAdvance.Name, "5000")
+
+	// Create buddy users
+	buddyUser1 := createTestUserInOrg(org)
+
+	// Switch to non-admin user
+	user := createTestUserInOrg(org)
+	user2 := createTestUserInOrg(org)
+	loginResponse := loginTestUser(user.ID)
+
+	// Create
+	payload := "{\"buddyId\": \"" + buddyUser1.ID + "\"}"
+	req := newHTTPRequest("POST", "/buddy/", user2.ID, bytes.NewBufferString(payload))
+	res := executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusCreated, res.Code)
+	id := res.Header().Get("X-Object-Id")
+
+	// Delete
+	req = newHTTPRequest("DELETE", "/buddy/"+id, loginResponse.UserID, nil)
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusForbidden, res.Code)
+}
+
+func TestBuddiesCreateWithMissingUser(t *testing.T) {
+	clearTestDB()
+	org := createTestOrg("test.com")
+	user2 := createTestUserOrgAdmin(org)
+	loginResponse2 := loginTestUser(user2.ID)
+	GetSettingsRepository().Set(org.ID, SettingMaxDaysInAdvance.Name, "5000")
+	GetSettingsRepository().Set(org.ID, SettingAllowBookingsNonExistingUsers.Name, "1")
+
+	// Create
+	payload := "{\"buddyId\": \"" + uuid.New().String() + "\"}"
+	req := newHTTPRequest("POST", "/buddy/", loginResponse2.UserID, bytes.NewBufferString(payload))
+	res := executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusBadRequest, res.Code)
+}
+
+func TestBuddiesList(t *testing.T) {
+	clearTestDB()
+	org := createTestOrg("test.com")
+	GetSettingsRepository().Set(org.ID, SettingMaxDaysInAdvance.Name, "5000")
+
+	// Create buddy users
+	buddyUser1 := createTestUserInOrg(org)
+	buddyUser2 := createTestUserInOrg(org)
+	buddyUser3 := createTestUserInOrg(org)
+
+	// Switch to non-admin user
+	user := createTestUserInOrg(org)
+	loginResponse := loginTestUser(user.ID)
+
+	// Create #1
+	payload := "{\"buddyId\": \"" + buddyUser1.ID + "\"}"
+	req := newHTTPRequest("POST", "/buddy/", loginResponse.UserID, bytes.NewBufferString(payload))
+	res := executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusCreated, res.Code)
+
+	// Create #2
+	payload = "{\"buddyId\": \"" + buddyUser2.ID + "\"}"
+	req = newHTTPRequest("POST", "/buddy/", loginResponse.UserID, bytes.NewBufferString(payload))
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusCreated, res.Code)
+
+	// Create #3(for a different user)
+	payload = "{\"buddyId\": \"" + buddyUser3.ID + "\"}"
+	req = newHTTPRequest("POST", "/buddy/", buddyUser2.ID, bytes.NewBufferString(payload))
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusCreated, res.Code)
+
+	// Read all buddies for user 1
+	req = newHTTPRequest("GET", "/buddy/", loginResponse.UserID, nil)
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusOK, res.Code)
+	var resBody []*GetBuddyResponse
+	json.Unmarshal(res.Body.Bytes(), &resBody)
+	if len(resBody) != 2 {
+		t.Fatalf("Expected array with 2 elements")
+	}
+	acceptedBuddyIDs := []string{buddyUser1.ID, buddyUser2.ID}
+	if !contains(acceptedBuddyIDs, resBody[0].BuddyID) {
+		t.Fatalf("Expected %s to one of %#v", resBody[0].BuddyID, acceptedBuddyIDs)
+	}
+	if !contains(acceptedBuddyIDs, resBody[1].BuddyID) {
+		t.Fatalf("Expected %s to one of %#v", resBody[1].BuddyID, acceptedBuddyIDs)
+	}
+
+	// Read all buddies for user 2
+	req = newHTTPRequest("GET", "/buddy/", buddyUser2.ID, nil)
+	res = executeTestRequest(req)
+	checkTestResponseCode(t, http.StatusOK, res.Code)
+	var resBody2 []*GetBuddyResponse
+	json.Unmarshal(res.Body.Bytes(), &resBody2)
+	if len(resBody2) != 1 {
+		t.Fatalf("Expected array with 1 elements")
+	}
+	checkTestString(t, buddyUser3.ID, resBody2[0].BuddyID)
+}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -234,3 +234,13 @@ func checkStringNotEmpty(t *testing.T, s string) {
 		t.Fatalf("Expected non-empty string at:\n%s", debug.Stack())
 	}
 }
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
When using the product, we've realised it's missing one very handy capability: seeing where are your buddies sitting. In this MR, a new REST API to store / remove / list buddies is added and FE changes to display with a different shade the bookings made by buddies(on search page), adding a new buddy(on search page) and a new page to manage buddies list(view & remove).

Potential follow-up improvements:
* Add tooltip over the booking with the email of buddy which booked it
* Add explanation what each color used on the search view means
* Search by email and add buddies directly on "My buddies" page

Note: in order to avoid weird UX, this feature requires "Show names" flag to be activated.

<img width="1567" alt="Screenshot 2024-01-07 at 22 25 41" src="https://github.com/seatsurfing/backend/assets/7695281/d206fd23-a80f-4142-9ed9-dbdf61575485">
<img width="1566" alt="Screenshot 2024-01-07 at 22 25 52" src="https://github.com/seatsurfing/backend/assets/7695281/ca0c9b3b-b54f-4c63-afbb-c44e2cf0c9ab">
<img width="1529" alt="Screenshot 2024-01-07 at 22 25 59" src="https://github.com/seatsurfing/backend/assets/7695281/20263116-3d89-473b-83a7-f0e7c9fb6a36">
<img width="1553" alt="Screenshot 2024-01-07 at 22 26 07" src="https://github.com/seatsurfing/backend/assets/7695281/a484063f-9a0c-4614-b480-ee83f5576795">
<img width="1566" alt="Screenshot 2024-01-07 at 22 26 20" src="https://github.com/seatsurfing/backend/assets/7695281/0258d0bf-4b49-4c2d-8d4e-0fd0872ddb1c">
