### PR TITLE
docker-refactor - not hardcode main-repo for commons

### DIFF
--- a/.github/workflows/build-admin-ui.yml
+++ b/.github/workflows/build-admin-ui.yml
@@ -38,7 +38,8 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         build-args: CI_VERSION=${{ env.CI_VERSION }}-dev
-        context: ./admin-ui
+        context: ./
+        file: Dockerfile.admin-ui
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |

--- a/.github/workflows/build-booking-ui.yml
+++ b/.github/workflows/build-booking-ui.yml
@@ -38,7 +38,8 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         build-args: CI_VERSION=${{ env.CI_VERSION }}-dev
-        context: ./booking-ui
+        context: ./
+        file: Dockerfile.booking-ui
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |

--- a/Dockerfile.admin-ui
+++ b/Dockerfile.admin-ui
@@ -1,11 +1,6 @@
 FROM node:20-alpine AS commons-builder
 WORKDIR /app
-RUN apk add git
-RUN git init && \
-    git remote add -f origin https://github.com/seatsurfing/backend.git && \
-    git config core.sparseCheckout true && \
-    echo 'commons' >> .git/info/sparse-checkout && \
-    git pull origin master
+ADD ./commons/ /app/commons
 WORKDIR /app/commons/ts
 RUN npm install
 RUN npm run build
@@ -15,7 +10,7 @@ ARG CI_VERSION
 ENV NEXT_PUBLIC_PRODUCT_VERSION=$CI_VERSION
 ENV NODE_ENV=production
 COPY --from=commons-builder /app/commons/ts/ /app/commons/ts
-ADD . /app/
+ADD admin-ui /app/
 WORKDIR /app
 RUN npm install
 RUN npm install --save ./commons/ts
@@ -27,11 +22,11 @@ RUN sed -i "s/const hostname = /const hostname = process.env.LISTEN_ADDR || /g" 
 
 FROM gcr.io/distroless/nodejs20-debian12
 ENV NODE_ENV=production
-ENV PORT=3001
+ENV PORT=3000
 WORKDIR /app
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=65532:65532 /app/build/standalone ./
 COPY --from=builder --chown=65532:65532 /app/build/static ./build/static
-EXPOSE 3001
+EXPOSE 3000
 USER 65532:65532
 CMD ["server.js"]

--- a/Dockerfile.booking-ui
+++ b/Dockerfile.booking-ui
@@ -1,12 +1,7 @@
 FROM node:20-alpine AS commons-builder
 WORKDIR /app
-RUN apk add git
-RUN git init && \
-    git remote add -f origin https://github.com/seatsurfing/backend.git && \
-    git config core.sparseCheckout true && \
-    echo 'commons' >> .git/info/sparse-checkout && \
-    git pull origin master
 WORKDIR /app/commons/ts
+ADD ./commons/ /app/commons
 RUN npm install
 RUN npm run build
 
@@ -15,7 +10,7 @@ ARG CI_VERSION
 ENV NEXT_PUBLIC_PRODUCT_VERSION=$CI_VERSION
 ENV NODE_ENV=production
 COPY --from=commons-builder /app/commons/ts/ /app/commons/ts
-ADD . /app/
+ADD booking-ui /app/
 WORKDIR /app
 RUN npm install
 RUN npm install --save ./commons/ts
@@ -27,11 +22,11 @@ RUN sed -i "s/const hostname = /const hostname = process.env.LISTEN_ADDR || /g" 
 
 FROM gcr.io/distroless/nodejs20-debian12
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV PORT=3001
 WORKDIR /app
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=65532:65532 /app/build/standalone ./
 COPY --from=builder --chown=65532:65532 /app/build/static ./build/static
-EXPOSE 3000
+EXPOSE 3001
 USER 65532:65532
 CMD ["server.js"]

--- a/docker-readme.md
+++ b/docker-readme.md
@@ -23,12 +23,17 @@ version: '3.7'
 services:
   server:
     image: seatsurfing/backend
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile
     restart: always
     networks:
       sql:
       http:
     ports:
       - 8080:8080
+    depends_on:
+      - db
     environment:
       POSTGRES_URL: 'postgres://seatsurfing:DB_PASSWORD@db/seatsurfing?sslmode=disable'
       JWT_SIGNING_KEY: 'some_random_string'
@@ -38,20 +43,26 @@ services:
       FRONTEND_URL: 'https://seatsurfing.your-domain.com'
   booking-ui:
     image: seatsurfing/booking-ui
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile.booking-ui
     restart: always
     networks:
       http:
     environment:
       FRONTEND_URL: 'https://seatsurfing.your-domain.com'
   admin-ui:
-    image: seatsurfing/admin-ui
+    image: seatsurfing/admin-ui:dev
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile.admin-ui
     restart: always
     networks:
       http:
     environment:
       FRONTEND_URL: 'https://seatsurfing.your-domain.com'
   db:
-    image: postgres:12
+    image: postgres:15-alpine
     restart: always
     networks:
       sql:

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3.7'
 
 services:
   server:
-    image: seatsurfing/backend:dev
+    image: seatsurfing/backend
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile
     restart: always
     networks:
       sql:
@@ -16,16 +19,28 @@ services:
       JWT_SIGNING_KEY: 'some_random_string'
       BOOKING_UI_BACKEND: 'booking-ui:3001'
       ADMIN_UI_BACKEND: 'admin-ui:3000'
+      PUBLIC_URL: 'https://seatsurfing.your-domain.com'
+      FRONTEND_URL: 'https://seatsurfing.your-domain.com'
   booking-ui:
-    image: seatsurfing/booking-ui:dev
+    image: seatsurfing/booking-ui
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile.booking-ui
     restart: always
     networks:
       http:
+    environment:
+      FRONTEND_URL: 'https://seatsurfing.your-domain.com'
   admin-ui:
     image: seatsurfing/admin-ui:dev
+    #build:
+    #  context: .
+    #  dockerfile: Dockerfile.admin-ui
     restart: always
     networks:
       http:
+    environment:
+      FRONTEND_URL: 'https://seatsurfing.your-domain.com'
   db:
     image: postgres:15-alpine
     restart: always
@@ -44,3 +59,4 @@ volumes:
 networks:
   sql:
   http:
+


### PR DESCRIPTION
uh, the Dockerfiles from admin-ui and booking-ui are getting the latest `commons` folder from latest master from github.

Why not just moving the Docker-Build-Context to the main-directory, using the "ADD commons" command, and moving all Dockerfiles with suffix also to the root folder.

This makes it much more easy for other to start hacking with the software, see the `examples/docker-compose.yml` file with the commented out `build` section.

same for the github-ci, i have changed the pipline. 