### PR TITLE
floor and space urls to be used as direct link/QR codes

### DIFF
--- a/admin-ui/public/locales/en/admin.json
+++ b/admin-ui/public/locales/en/admin.json
@@ -75,6 +75,7 @@
     "errorLoginFailed": "Login failed.",
     "loginFailedDescription": "Possibly your account is not activated in this organization.",
     "map": "Map",
+    "bookingLink": "Booking Link",
     "admin": "Administrator",
     "yes": "Yes",
     "loginMeans": "Login",

--- a/admin-ui/src/pages/locations/index.tsx
+++ b/admin-ui/src/pages/locations/index.tsx
@@ -55,6 +55,7 @@ class Locations extends React.Component<Props, State> {
       <tr key={location.id} onClick={() => this.onItemSelect(location)}>
         <td>{location.name}</td>
         <td>{location.mapWidth}x{location.mapHeight}</td>
+        <td>{window.location.origin}/ui/search?lid={location.id}</td>
       </tr>
     );
   }
@@ -104,6 +105,7 @@ class Locations extends React.Component<Props, State> {
             <tr>
               <th>{this.props.t("name")}</th>
               <th>{this.props.t("map")}</th>
+              <th>{this.props.t("bookingLink")}</th>
             </tr>
           </thead>
           <tbody>

--- a/booking-ui/src/components/NavBar.tsx
+++ b/booking-ui/src/components/NavBar.tsx
@@ -41,6 +41,9 @@ class NavBar extends React.Component<Props, State> {
     }
 
     componentDidMount = () => {
+        if (!Ajax.CREDENTIALS.accessToken) {
+            return;
+        }
         this.loadData();
     }
 

--- a/booking-ui/src/pages/login/index.tsx
+++ b/booking-ui/src/pages/login/index.tsx
@@ -130,9 +130,9 @@ class Login extends React.Component<Props, State> {
           Ajax.PERSISTER.persistRefreshTokenInLocalStorage(Ajax.CREDENTIALS);
         }
         RuntimeConfig.setLoginDetails().then(() => {
-          this.setState({
-            redirect: "/search"
-          });
+          let redirect = this.props.router.query["redir"] as string || "/search";
+
+          this.setState({ redirect });
         });
       });
     }).catch(() => {

--- a/booking-ui/src/pages/search.tsx
+++ b/booking-ui/src/pages/search.tsx
@@ -99,7 +99,7 @@ class Search extends React.Component<Props, State> {
   componentDidMount = () => {
     console.log(RuntimeConfig.INFOS);
     if (!Ajax.CREDENTIALS.accessToken) {
-      this.props.router.push("/login");
+      this.props.router.push({pathname: "/login", query: { redir: this.props.router.asPath }});
       return;
     }
     this.loadItems();
@@ -116,15 +116,20 @@ class Search extends React.Component<Props, State> {
       if (this.state.locationId === "" && this.locations.length > 0) {
         let defaultLocationId = this.locations[0].id;
         if (this.state.prefLocationId) {
-          this.locations.forEach(location => {
-            if (location.id === this.state.prefLocationId) {
-              defaultLocationId = this.state.prefLocationId;
-            }
-          })
+          defaultLocationId = this.locations.find((e) => e.id === this.state.prefLocationId)?.id || defaultLocationId;
         }
+        let lidParam = this.props.router.query["lid"] as string || "";
+        if (lidParam) {
+          defaultLocationId = this.locations.find((e) => e.id === lidParam)?.id || defaultLocationId;
+        }
+        let sidParam = this.props.router.query["sid"] as string || "";
         this.setState({ locationId: defaultLocationId }, () => {
           this.loadMap(this.state.locationId).then(() => {
             this.setState({ loading: false });
+            if (sidParam) {
+              let space = this.data.find( (item) => item.id == sidParam);
+              if (space) this.onSpaceSelect(space);
+            }
           });
         });
       } else {


### PR DESCRIPTION
fixes seatsurfing/backend#202 & fixes seatsurfing/backend#203

ui/search can now accept "lid" and "sid" parameters to jump directly to a location map by id and a space id booking dialog.

If the accessToken is invalid, the login route is pushed with a "redir" parameter so the original url can be retried after login.

The xlsx export from the admin/locations interface now includes the location url. I added a space table underneath the map with a download button to get a similar xlsx export.

I also fixed an issue where each space would appear twice in the admin map, but this could be a development only.

![Screen Shot 2024-08-15 at 3 04 49 PM](https://github.com/user-attachments/assets/18e524d9-c62e-4be8-9e5f-cd83d36aef94)

![Screen Shot 2024-08-15 at 3 04 40 PM](https://github.com/user-attachments/assets/0fa9f02a-764d-4b9f-98b2-789a1692e09c)

