### PR TITLE
Auth provider redirect

### DIFF
--- a/admin-ui/public/locales/en/admin.json
+++ b/admin-ui/public/locales/en/admin.json
@@ -104,6 +104,7 @@
     "deleteSpace": "Delete space",
     "addSpace": "Add space",
     "floorplan": "Floorplan",
+    "saveAreaToGetLink": "Save area to get a valid link",
     "confluenceServerSharedSecret": "Confluence Shared Secret",
     "confluenceAnonymous": "Allow anonymous Confluence users (for demonstration purposes only)",
     "description": "Description",

--- a/admin-ui/src/pages/locations/[id].tsx
+++ b/admin-ui/src/pages/locations/[id].tsx
@@ -318,7 +318,7 @@ class EditLocation extends React.Component<Props, State> {
     return (
       <tr key={space.id} >
         <td>{space.name}</td>
-        <td>{window.location.origin}/ui/search?lid={this.entity.id}&sid={space.id}</td>
+        <td>{space.id ? `${window.location.origin}/ui/search?lid=${this.entity.id}&sid=${space.id}` : this.props.t("saveAreaToGetLink")}</td>
       </tr>
     );
   }

--- a/booking-ui/public/locales/en/common.json
+++ b/booking-ui/public/locales/en/common.json
@@ -93,6 +93,8 @@
     "workingHours": "Working hours",
     "to": "to",
     "showList": "Show List",
+    "week": "Week",
+    "map": "Map",
     "showMap": "Show Map",
     "gotoBooking": "Show Booking",
     "administration": "Administration",

--- a/booking-ui/src/pages/login/index.tsx
+++ b/booking-ui/src/pages/login/index.tsx
@@ -168,6 +168,10 @@ class Login extends React.Component<Props, State> {
     if (this.state.rememberMe) {
       target += "/1"
     }
+    let redir = this.props.router.query["redir"] as string;
+    if (redir) {
+      target += "?redir=" + encodeURIComponent(redir);
+    }
     window.location.href = target;
   }
 

--- a/booking-ui/src/pages/login/success/[id].tsx
+++ b/booking-ui/src/pages/login/success/[id].tsx
@@ -41,8 +41,9 @@ class LoginSuccess extends React.Component<Props, State> {
           }
           Ajax.PERSISTER.updateCredentialsSessionStorage(Ajax.CREDENTIALS).then(() => {
             RuntimeConfig.setLoginDetails().then(() => {
+              let redirect = this.props.router.query["redir"] as string || "/search";
               this.setState({
-                redirect: "/search"
+                redirect
               });
             });
           });


### PR DESCRIPTION
Fixes seatsurfing/backend#265 - handle the 'redir' parameter when signing in with auth providers.

Also added a "Save area to get a valid link" message instead of displaying an invalid link after creating a new space.

Added missing translation keys

