### PR TITLE
Always show Search Box at the Bottom

### DIFF
--- a/booking-ui/src/pages/search.tsx
+++ b/booking-ui/src/pages/search.tsx
@@ -728,53 +728,53 @@ class Search extends React.Component<Props, State> {
           <CollapseIcon color={'#555'} height="20px" width="20px" cssClasses="expand-icon expand-icon-smallscreen" />
         </div>
         <div className="content-minimized">
-          <Row>
-            <Col xs="2"><LocationIcon title={this.props.t("area")} color={'#555'} height="20px" width="20px" /></Col>
-            <Col xs="10">{this.getLocationName()}</Col>
-          </Row>
-          <Row>
-            <Col xs="2"><EnterIcon title={this.props.t("enter")} color={'#555'} height="20px" width="20px" /></Col>
-            <Col xs="10">{Formatting.getFormatterShort().format(Formatting.convertToFakeUTCDate(new Date(this.state.enter)))}</Col>
-          </Row>
-          <Row>
-            <Col xs="2"><ExitIcon title={this.props.t("leave")} color={'#555'} height="20px" width="20px" /></Col>
-            <Col xs="10">{Formatting.getFormatterShort().format(Formatting.convertToFakeUTCDate(new Date(this.state.leave)))}</Col>
-          </Row>
+          <div className='d-flex'>
+            <div className='me-2'><LocationIcon title={this.props.t("area")} color={'#555'} height="20px" width="20px" /></div>
+            <div className='ms-2 w-100'>{this.getLocationName()}</div>
+          </div>
+          <div className='d-flex'>
+            <div className='me-2'><EnterIcon title={this.props.t("enter")} color={'#555'} height="20px" width="20px" /></div>
+            <div className='ms-2 w-100'>{Formatting.getFormatterShort().format(Formatting.convertToFakeUTCDate(new Date(this.state.enter)))}</div>
+          </div>
+          <div className='d-flex'>
+            <div className='me-2'><ExitIcon title={this.props.t("leave")} color={'#555'} height="20px" width="20px" /></div>
+            <div className='ms-2 w-100'>{Formatting.getFormatterShort().format(Formatting.convertToFakeUTCDate(new Date(this.state.leave)))}</div>
+          </div>
         </div>
         <div className="content">
           <Form>
-            <Form.Group as={Row}>
-              <Col xs="2" className='pt-1'><LocationIcon title={this.props.t("area")} color={'#555'} height="20px" width="20px" /></Col>
-              <Col xs="10">
+            <Form.Group className="d-flex">
+              <div className='pt-1 me-2'><LocationIcon title={this.props.t("area")} color={'#555'} height="20px" width="20px" /></div>
+              <div className='ms-2 w-100'>
                 <Form.Select required={true} value={this.state.locationId} onChange={(e) => this.changeLocation(e.target.value)}>
                   {this.renderLocations()}
                 </Form.Select>
-              </Col>
+              </div>
             </Form.Group>
-            <Form.Group as={Row} className="margin-top-10">
-              <Col xs="2"  className='pt-1'><EnterIcon title={this.props.t("enter")} color={'#555'} height="20px" width="20px" /></Col>
-              <Col xs="10">
+            <Form.Group className="d-flex margin-top-10">
+              <div className='pt-1 me-2'><EnterIcon title={this.props.t("enter")} color={'#555'} height="20px" width="20px" /></div>
+              <div className='ms-2 w-100'>
                 {enterDatePicker}
-              </Col>
+              </div>
             </Form.Group>
-            <Form.Group as={Row} className="margin-top-10">
-              <Col xs="2" className='pt-1'><ExitIcon title={this.props.t("leave")} color={'#555'} height="20px" width="20px" /></Col>
-              <Col xs="10">
+            <Form.Group className="d-flex margin-top-10">
+              <div className='pt-1 me-2'><ExitIcon title={this.props.t("leave")} color={'#555'} height="20px" width="20px" /></div>
+              <div className='ms-2 w-100'>
                 {leaveDatePicker}
-              </Col>
+              </div>
             </Form.Group>
             {hint}
-            <Form.Group as={Row} className="margin-top-10">
-              <Col xs="2"><WeekIcon title={this.props.t("week")} color={'#555'} height="20px" width="20px" /></Col>
-              <Col xs="10">
+            <Form.Group className="d-flex margin-top-10">
+              <div className='me-2'><WeekIcon title={this.props.t("week")} color={'#555'} height="20px" width="20px" /></div>
+              <div className='ms-2 w-100'>
                 <Form.Range disabled={this.state.daySliderDisabled} list="weekDays" min={0} max={RuntimeConfig.INFOS.maxDaysInAdvance} step="1" value={this.state.daySlider} onChange={(event) => this.changeEnterDay(window.parseInt(event.target.value))} />
-              </Col>
+              </div>
             </Form.Group>
-            <Form.Group as={Row} className="margin-top-10">
-              <Col xs="2"><MapIcon title={this.props.t("map")} color={'#555'} height="20px" width="20px" /></Col>
-              <Col xs="10">
+            <Form.Group className="d-flex margin-top-10">
+              <div className='me-2'><MapIcon title={this.props.t("map")} color={'#555'} height="20px" width="20px" /></div>
+              <div className='ms-2 w-100'>
                 <Form.Check type="switch" checked={!this.state.listView} onChange={() => this.toggleListView()} label={this.state.listView ? this.props.t("showList") : this.props.t("showMap")} />
-              </Col>
+              </div>
             </Form.Group>
           </Form>
         </div>

--- a/booking-ui/src/styles/Search.css
+++ b/booking-ui/src/styles/Search.css
@@ -1,8 +1,6 @@
 .react-date-picker,
 .react-datetime-picker {
-    padding: 10px;
-    padding-top: 5px;
-    padding-bottom: 4px;
+    padding: 5px 10px 4px;
     display: block;
     font-size: 16px;
     font-weight: 400;
@@ -28,10 +26,10 @@
 .container-map {
     margin-left: auto;
     margin-right: auto;
-    padding-top: 100px;
-    padding-left: 50px;
-    padding-right: 50px;
-    padding-bottom: 50px;
+    padding-top: 70px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 270px;
 }
 
 .mapScrollContainer {
@@ -75,19 +73,24 @@
 }
 
 .container-search-config {
-    border-radius: 10px;
-    box-shadow: 0px 0px 3px #555;
-    width: 350px;
     position: fixed;
-    top: 80px;
-    left: 30px;
-    background-color: white;
+    top: auto;
+    bottom: 0px;
+    left: 0px;
+    width: 100%;
+    height: 250px;
     padding: 20px;
     padding-top: 0px;
-    transition: all .2s;
+    border-radius: 10px;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+    box-shadow: 0px 0px 3px #555;
+    background-color: white;
     opacity: 0.95;
     z-index: 100;
+    transition: all .2s;
 }
+
 .container-search-config .content-minimized {
     display: none;
 }
@@ -97,9 +100,10 @@
 }
 
 .container-search-config.minimized {
-    width: 48px;
-    height: 48px;
-    padding: 0px;
+    width: 100%;
+    height: 130px;
+    padding: 20px;
+    padding-top: 0px;
     transition: all .2s;
 }
 
@@ -108,43 +112,41 @@
 }
 
 .container-search-config .collapse-bar {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+    margin-bottom: 10px;
     text-align: right;
-    margin-bottom: 20px;
     cursor: pointer;
 }
 
 .container-search-config.minimized .collapse-bar {
     text-align: center;
-    padding-top: 11px;
-    padding-bottom: 11px;
+    padding-top: 0px;
+    padding-bottom: 0px;
 }
 
-.container-search-config .collapse-bar .expand-icon {
-    display: none;
-}
-
-.container-search-config .collapse-bar .expand-icon-bigscreen {
-    display: none;
-}
-
-.container-search-config .collapse-bar .expand-icon-smallscreen {
-    display: none;
-}
-
-.container-search-config.minimized .collapse-bar .expand-icon-bigscreen {
-    display: inline;
-}
-
-.container-search-config .collapse-bar .collapse-icon-smallscreen {
-    display: none;
-}
-
+.container-search-config .collapse-bar .expand-icon,
+.container-search-config .collapse-bar .expand-icon-bigscreen,
+.container-search-config .collapse-bar .expand-icon-smallscreen,
+.container-search-config .collapse-bar .collapse-icon-bigscreen,
+.container-search-config.minimized .collapse-bar .expand-icon-bigscreen,
 .container-search-config.minimized .collapse-bar .collapse-icon {
     display: none;
 }
 
+.container-search-config.minimized .content-minimized,
+.container-search-config .collapse-bar .collapse-icon-smallscreen {
+    display: block;
+}
+
+.container-search-config.minimized .collapse-bar .expand-icon-smallscreen {
+    display: inline;
+}
+
 .space-list {
     text-align: left;
+    padding-bottom: 250px;
 }
 
 .space {
@@ -175,39 +177,16 @@
 
 .invalid-search-config {
     width: 100%;
-
     font-size: .875em;
     color: #dc3545;
 }
 
-.space-list {
-    padding-bottom: 250px;
-}
 .space-list.maximized {
     padding-bottom: 130px;
 }
 
-.container-map {
-    margin-left: auto;
-    margin-right: auto;
-    padding-top: 70px;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-bottom: 270px;
-}
 .container-map.maximized {
     padding-bottom: 150px;
-}
-
-.container-search-config {
-    width: 100%;
-    bottom: 0px;
-    top: auto;
-    left: 0px;
-    height: 250px;
-    border-bottom-left-radius: 0px;
-    border-bottom-right-radius: 0px;
-    transition: height .2s;
 }
 
 @media only screen and (min-width: 440px) {
@@ -216,44 +195,4 @@
         max-width: 420px;
         left: 10px;
     }
-}
-
-.container-search-config.minimized {
-    width: 100%;
-    height: 130px;
-    transition: height .2s;
-    padding: 20px;
-    padding-top: 0px;
-}
-
-.container-search-config.minimized .content-minimized {
-    display: block;
-}
-
-.container-search-config .collapse-bar {
-    display: flex;
-    justify-content: center;
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
-
-.container-search-config.minimized .collapse-bar {
-    padding-top: 0px;
-    padding-bottom: 0px;
-}
-
-.container-search-config .collapse-bar .collapse-icon-smallscreen {
-    display: block;
-}
-
-.container-search-config .collapse-bar .collapse-icon-bigscreen {
-    display: none;
-}
-
-.container-search-config.minimized .collapse-bar .expand-icon-bigscreen {
-    display: none;
-}
-
-.container-search-config.minimized .collapse-bar .expand-icon-smallscreen {
-    display: inline;
 }

--- a/booking-ui/src/styles/Search.css
+++ b/booking-ui/src/styles/Search.css
@@ -180,74 +180,72 @@
     color: #dc3545;
 }
 
-@media only screen and (max-width: 600px), only screen and (max-height: 500px) {
-    .space-list {
-        padding-bottom: 250px;
-    }
-    .space-list.maximized {
-        padding-bottom: 130px;
-    }
+.space-list {
+    padding-bottom: 250px;
+}
+.space-list.maximized {
+    padding-bottom: 130px;
+}
 
-    .container-map {
-        margin-left: auto;
-        margin-right: auto;
-        padding-top: 70px;
-        padding-left: 10px;
-        padding-right: 10px;
-        padding-bottom: 250px;
-    }
-    .container-map.maximized {
-        padding-bottom: 130px;
-    }
+.container-map {
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 70px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 250px;
+}
+.container-map.maximized {
+    padding-bottom: 130px;
+}
 
-    .container-search-config {
-        width: 100%;
-        bottom: 0px;
-        top: auto;
-        left: 0px;
-        height: 250px;
-        border-bottom-left-radius: 0px;
-        border-bottom-right-radius: 0px;
-        transition: height .2s;
-    }
+.container-search-config {
+    width: 100%;
+    bottom: 0px;
+    top: auto;
+    left: 0px;
+    height: 250px;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+    transition: height .2s;
+}
 
-    .container-search-config.minimized {
-        width: 100%;
-        height: 130px;
-        transition: height .2s;
-        padding: 20px;
-        padding-top: 0px;
-    }
+.container-search-config.minimized {
+    width: 100%;
+    height: 130px;
+    transition: height .2s;
+    padding: 20px;
+    padding-top: 0px;
+}
 
-    .container-search-config.minimized .content-minimized {
-        display: block;
-    }
+.container-search-config.minimized .content-minimized {
+    display: block;
+}
 
-    .container-search-config .collapse-bar {
-        display: flex;
-        justify-content: center;
-        margin-top: 10px;
-        margin-bottom: 10px;
-    }
+.container-search-config .collapse-bar {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
 
-    .container-search-config.minimized .collapse-bar {
-        padding-top: 0px;
-        padding-bottom: 0px;
-    }
+.container-search-config.minimized .collapse-bar {
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
 
-    .container-search-config .collapse-bar .collapse-icon-smallscreen {
-        display: block;
-    }
+.container-search-config .collapse-bar .collapse-icon-smallscreen {
+    display: block;
+}
 
-    .container-search-config .collapse-bar .collapse-icon-bigscreen {
-        display: none;
-    }
+.container-search-config .collapse-bar .collapse-icon-bigscreen {
+    display: none;
+}
 
-    .container-search-config.minimized .collapse-bar .expand-icon-bigscreen {
-        display: none;
-    }
+.container-search-config.minimized .collapse-bar .expand-icon-bigscreen {
+    display: none;
+}
 
-    .container-search-config.minimized .collapse-bar .expand-icon-smallscreen {
-        display: inline;
-    }
+.container-search-config.minimized .collapse-bar .expand-icon-smallscreen {
+    display: inline;
 }

--- a/booking-ui/src/styles/Search.css
+++ b/booking-ui/src/styles/Search.css
@@ -193,10 +193,10 @@
     padding-top: 70px;
     padding-left: 10px;
     padding-right: 10px;
-    padding-bottom: 250px;
+    padding-bottom: 270px;
 }
 .container-map.maximized {
-    padding-bottom: 130px;
+    padding-bottom: 150px;
 }
 
 .container-search-config {
@@ -208,6 +208,14 @@
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
     transition: height .2s;
+}
+
+@media only screen and (min-width: 440px) {
+    .container-search-config {
+        width: calc(100% - 20px);
+        max-width: 420px;
+        left: 10px;
+    }
 }
 
 .container-search-config.minimized {


### PR DESCRIPTION
First of all: thank you for this fantastic project!

When using Seatsurfing on a desktop computer, the search box can be inconvenient and thus very annoying as it overlays the floor plan. If there are spaces under the box, they are not seen very good and  they are hard to select. E.g. Room 1 with Spaces 1 and 2 in this image:

![localhost_8079_ui_search(Laptop Midi) (5)](https://github.com/user-attachments/assets/80046806-a97a-48fe-b60a-0799463224c2)

This PR moves the search box to the bottom below the image, just as in the mobile view. It basically just removes the media breakpoint and uses the styles for mobile also for desktop.

Further there are some minor improvements:
- it adds a maximum width to the box, so it does not span the whole monitor on desktop
- it adds some more space between image and search box
- it replaces the fixed row/column structure with a flex box

At the end it looks like this:

![localhost_8079_ui_search(Laptop Midi) (3)](https://github.com/user-attachments/assets/f3810861-440a-48f7-86fa-61d3c1df8db6)

It can be easily scrolled down to reach any space on a floor:

![localhost_8079_ui_search(Laptop Midi) (4)](https://github.com/user-attachments/assets/55940d18-2868-4bbe-ab5b-74fd25506c84)

It's not perfect or beautiful either, but I see it as an improvement to the problem described above.