### PR TITLE
fix: keycloak OIDC template defaults

### DIFF
--- a/ui/src/pages/admin/settings/auth-providers/[id].tsx
+++ b/ui/src/pages/admin/settings/auth-providers/[id].tsx
@@ -187,14 +187,14 @@ class EditAuthProvider extends React.Component<Props, State> {
       tokenUrl:
         "https://keycloakhost.sample/auth/realms/master/protocol/openid-connect/token",
       authStyle: 1,
-      scopes: "openid,email",
+      scopes: "openid email",
       userInfoUrl:
         "https://keycloakhost.sample/auth/realms/master/protocol/openid-connect/userinfo",
-      userInfoEmailField: "email,profile",
+      userInfoEmailField: "email",
       userInfoFirstnameField: "given_name",
       userInfoLastnameField: "family_name",
       logoutUrl:
-        "https://keycloakhost.sample/auth/realms/master/protocol/openid-connect/logout?post_logout_redirect_uri={logoutRedirectUri}",
+        "https://keycloakhost.sample/auth/realms/master/protocol/openid-connect/logout?client_id=CLIENT_ID&post_logout_redirect_uri={logoutRedirectUri}",
     });
   };
 


### PR DESCRIPTION
This PR fixes several default values in the Keycloak OIDC auth provider template to prevent common configuration issues.

### Changes

- Fix scope formatting: use whitespace-separated scopes (_openid email_) instead of comma-separated values
- Fix userInfoEmailField: use email instead of email,profile
- Adjust logout URL template to include client_id, preventing Keycloak from showing _Missing parameters: id_token_hint_

### Why
With the previous defaults:

- the email claim could not be resolved correctly
- logout resulted in a Keycloak error page

These changes make the Keycloak provider work out-of-the-box with recent Keycloak versions (tested with Keycloak 26.5.1), without requiring code changes.

### Tested with

- Keycloak 26.5.1
- Seatsurfing 1.53.2 behind a reverse proxy (Caddy)

Thanks for maintaining Seatsurfing! 🙌

_Note: This only updates the pre-filled template values and does not change the authentication logic. Logout experience would improve, if id_token_hint={id_token} could be added to the logout url_