### PR TITLE
fix(server): domain verification incorrectly uses port 80 instead of 443

### DIFF
--- a/server/util/domain-verification.go
+++ b/server/util/domain-verification.go
@@ -37,17 +37,36 @@ func IsValidTXTRecord(domain, uuid string) bool {
 }
 
 func IsDomainAccessible(domain, orgID string) (bool, error) {
-	if err := isDomainAccessible("https", domain, 443, orgID); err == nil {
+	cfg := GetConfig()
+	var lastErr error
+
+	// Try with the configured public scheme and port first
+	if lastErr = isDomainAccessible(cfg.PublicScheme, domain, cfg.PublicPort, orgID); lastErr == nil {
 		return true, nil
 	}
-	httpPort := 80
-	if GetConfig().Development {
-		httpPort, _ = strconv.Atoi(GetConfig().PublicListenAddr[strings.Index(GetConfig().PublicListenAddr, ":")+1:])
+
+	// Fall back to https/443 if not already tried above
+	if !(cfg.PublicScheme == "https" && cfg.PublicPort == 443) {
+		if lastErr = isDomainAccessible("https", domain, 443, orgID); lastErr == nil {
+			return true, nil
+		}
 	}
-	if err := isDomainAccessible("http", domain, httpPort, orgID); err != nil {
-		return false, err
+
+	// Fall back to http only when the configured public scheme is not https,
+	// to avoid redirect loops caused by ingress controllers redirecting http→https.
+	if cfg.PublicScheme != "https" {
+		httpPort := 80
+		if cfg.Development {
+			httpPort, _ = strconv.Atoi(cfg.PublicListenAddr[strings.Index(cfg.PublicListenAddr, ":")+1:])
+		}
+		if !(cfg.PublicScheme == "http" && cfg.PublicPort == httpPort) {
+			if lastErr = isDomainAccessible("http", domain, httpPort, orgID); lastErr == nil {
+				return true, nil
+			}
+		}
 	}
-	return true, nil
+
+	return false, lastErr
 }
 
 func isDomainAccessible(scheme, domain string, port int, orgID string) error {

--- a/server/util/test/domain-verification_test.go
+++ b/server/util/test/domain-verification_test.go
@@ -1,7 +1,12 @@
 package test
 
 import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	. "github.com/seatsurfing/seatsurfing/server/config"
@@ -21,4 +26,114 @@ func TestDomainVerificationCustomResolver(t *testing.T) {
 	GetConfig().ReadConfig()
 	CheckTestBool(t, true, IsValidTXTRecord("seatsurfing-testcase.virtualzone.de", "65e51a4b-339f-4b24-b376-f9d866057b38"))
 	CheckTestBool(t, false, IsValidTXTRecord("seatsurfing-testcase.virtualzone.de", "invalid-uuid"))
+}
+
+// setAccessibilityConfig configures PUBLIC_SCHEME/PUBLIC_PORT and registers a cleanup
+// that restores the previous config after the test.
+func setAccessibilityConfig(t *testing.T, scheme, port string) {
+	t.Helper()
+	prevScheme := os.Getenv("PUBLIC_SCHEME")
+	prevPort := os.Getenv("PUBLIC_PORT")
+	os.Setenv("PUBLIC_SCHEME", scheme)
+	os.Setenv("PUBLIC_PORT", port)
+	GetConfig().ReadConfig()
+	t.Cleanup(func() {
+		os.Setenv("PUBLIC_SCHEME", prevScheme)
+		os.Setenv("PUBLIC_PORT", prevPort)
+		GetConfig().ReadConfig()
+	})
+}
+
+// accessibilityHandler returns an HTTP handler that writes a DomainAccessibilityPayload
+// JSON response with the given domain, orgID and status.
+func accessibilityHandler(domain, orgID, status string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"domain":%q,"orgID":%q,"status":%q}`, domain, orgID, status)
+	}
+}
+
+// TestIsDomainAccessibleSuccess verifies that IsDomainAccessible returns true when
+// the server at the configured PUBLIC_SCHEME/PUBLIC_PORT returns a valid response.
+func TestIsDomainAccessibleSuccess(t *testing.T) {
+	const orgID = "test-org-id"
+	const domain = "127.0.0.1"
+
+	srv := httptest.NewServer(accessibilityHandler(domain, orgID, "OK"))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	setAccessibilityConfig(t, "http", strconv.Itoa(port))
+
+	ok, err := IsDomainAccessible(domain, orgID)
+	CheckTestBool(t, true, ok)
+	CheckTestBool(t, true, err == nil)
+}
+
+// TestIsDomainAccessibleWrongOrgID verifies that IsDomainAccessible returns false
+// when the server returns a payload with a mismatched orgID.
+func TestIsDomainAccessibleWrongOrgID(t *testing.T) {
+	const domain = "127.0.0.1"
+
+	srv := httptest.NewServer(accessibilityHandler(domain, "other-org-id", "OK"))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	setAccessibilityConfig(t, "http", strconv.Itoa(port))
+
+	ok, err := IsDomainAccessible(domain, "expected-org-id")
+	CheckTestBool(t, false, ok)
+	CheckTestBool(t, false, err == nil)
+}
+
+// TestIsDomainAccessibleWrongDomain verifies that IsDomainAccessible returns false
+// when the server returns a payload with a mismatched domain.
+func TestIsDomainAccessibleWrongDomain(t *testing.T) {
+	const orgID = "test-org-id"
+	const domain = "127.0.0.1"
+
+	srv := httptest.NewServer(accessibilityHandler("other.domain", orgID, "OK"))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	setAccessibilityConfig(t, "http", strconv.Itoa(port))
+
+	ok, err := IsDomainAccessible(domain, orgID)
+	CheckTestBool(t, false, ok)
+	CheckTestBool(t, false, err == nil)
+}
+
+// TestIsDomainAccessibleBadStatus verifies that IsDomainAccessible returns false
+// when the server returns a non-OK status in the payload.
+func TestIsDomainAccessibleBadStatus(t *testing.T) {
+	const orgID = "test-org-id"
+	const domain = "127.0.0.1"
+
+	srv := httptest.NewServer(accessibilityHandler(domain, orgID, "FAIL"))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	setAccessibilityConfig(t, "http", strconv.Itoa(port))
+
+	ok, err := IsDomainAccessible(domain, orgID)
+	CheckTestBool(t, false, ok)
+	CheckTestBool(t, false, err == nil)
+}
+
+// TestIsDomainAccessibleUnreachable verifies that IsDomainAccessible returns false
+// when no server is reachable on any of the attempted scheme/port combinations.
+func TestIsDomainAccessibleUnreachable(t *testing.T) {
+	// Grab a free port then immediately release it so nothing is listening there.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	setAccessibilityConfig(t, "http", strconv.Itoa(port))
+
+	ok, err := IsDomainAccessible("127.0.0.1", "test-org-id")
+	CheckTestBool(t, false, ok)
+	CheckTestBool(t, false, err == nil)
 }

--- a/server/util/test/test_test.go
+++ b/server/util/test/test_test.go
@@ -11,5 +11,7 @@ import (
 func TestMain(m *testing.M) {
 	pwd, _ := os.Getwd()
 	os.Setenv("FILESYSTEM_BASE_PATH", filepath.Join(pwd, "../../"))
+	// Set a 32-byte CRYPT_KEY for testing TOTP encryption
+	os.Setenv("CRYPT_KEY", "12345678901234567890123456789012")
 	TestRunner(m)
 }


### PR DESCRIPTION
Under certain circumstances, the domain accessibility test fails.

In issue #2108, the following happens:

1. TLS terminates at the HAProxy ingress — internally the pod speaks plain HTTP on port 8080.
1. The backend first tries https://desk-t.customdomain.de:443/… internally. DNS resolves to the ClusterIP service which routes port 443 → pod port 8080 (plain HTTP). The Go TLS client gets a plain-HTTP response → error.
1. It then falls back to http://desk-t.customdomain.de:80/…. HAProxy (listening on port 80) issues an HTTP→HTTPS redirect. If that redirect preserves port 80 (i.e. https://…:80/…), Go follows it, tries TLS on port 80, gets plain HTTP again → the exact error the reporter sees: "http: server gave HTTP response to HTTPS client".

Fix: `IsDomainAccessible` should use `GetConfig().PublicScheme` and `GetConfig().PublicPort` as the primary attempt instead of hardcoding https/443.