### PR TITLE
fix(admin-ui): only allow setting verified domains as primary

### DIFF
--- a/server/router/organization-router.go
+++ b/server/router/organization-router.go
@@ -342,9 +342,14 @@ func (router *OrganizationRouter) setPrimaryDomain(w http.ResponseWriter, r *htt
 		SendForbidden(w)
 		return
 	}
-	if _, err = GetOrganizationRepository().GetDomain(e, vars["domain"]); err != nil {
+	domain, err := GetOrganizationRepository().GetDomain(e, vars["domain"])
+	if err != nil {
 		log.Println(err)
 		SendNotFound(w)
+		return
+	}
+	if !domain.Active {
+		SendBadRequest(w)
 		return
 	}
 	GetOrganizationRepository().SetPrimaryDomain(e, vars["domain"])

--- a/server/router/test/organization-router_test.go
+++ b/server/router/test/organization-router_test.go
@@ -664,7 +664,17 @@ func TestOrganizationsPrimaryDomain(t *testing.T) {
 	CheckTestBool(t, false, resBody[1].Primary)
 	CheckTestBool(t, false, resBody[2].Primary)
 
-	// Set domain 2 as primary
+	// Set domain 2 as primary - should fail because it's not active
+	req = NewHTTPRequest("POST", "/organization/"+org.ID+"/domain/test2.com/primary", loginResponse.UserID, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusBadRequest, res.Code)
+
+	// Mark domain 2 as active
+	if err := GetOrganizationRepository().ActivateDomain(org, "test2.com"); err != nil {
+		t.Fatalf("Failed to get domain: %v", err)
+	}
+
+	// Set domain 2 as primary - should succeed
 	req = NewHTTPRequest("POST", "/organization/"+org.ID+"/domain/test2.com/primary", loginResponse.UserID, nil)
 	res = ExecuteTestRequest(req)
 	CheckTestResponseCode(t, http.StatusNoContent, res.Code)

--- a/ui/src/pages/admin/settings/index.tsx
+++ b/ui/src/pages/admin/settings/index.tsx
@@ -642,6 +642,7 @@ class Settings extends React.Component<Props, State> {
             variant="secondary"
             size="sm"
             hidden={domain.primary}
+            disabled={!domain.active}
             onClick={() => this.setPrimaryDomain(domain.domain)}
           >
             Primary


### PR DESCRIPTION
Current behavior:
It's possible to flag a non-verified domain as primary. This leads to fallback logic in `GetPrimaryDomain()`, so it still uses the non-primary, but active default `localhost` domain.

New behavior:
It's only possible to mark successfully verified domains as primary.