### PR TITLE
feat(server): support api tokens for service accounts

### DIFF
--- a/server/repository/db-updates.go
+++ b/server/repository/db-updates.go
@@ -11,7 +11,7 @@ import (
 )
 
 func RunDBSchemaUpdates() {
-	targetVersion := 42
+	targetVersion := 43
 	curVersion, err := GetSettingsRepository().GetGlobalInt(SettingDatabaseVersion.Name)
 	log.Printf("Initializing database with schema version %d (current: %d) …\n", targetVersion, curVersion)
 	if err != nil {

--- a/server/repository/user-repository.go
+++ b/server/repository/user-repository.go
@@ -47,6 +47,7 @@ type User struct {
 	BanExpiry              *time.Time
 	LastActivityAtUTC      *time.Time
 	TotpSecret             NullString
+	ApiToken               NullString
 }
 
 func (u *User) GetDisplayName() string {
@@ -169,6 +170,15 @@ func (r *UserRepository) RunSchemaUpgrade(curVersion, targetVersion int) {
 			panic(err)
 		}
 	}
+	if curVersion < 43 {
+		if _, err := GetDatabase().DB().Exec("ALTER TABLE users " +
+			"ADD COLUMN IF NOT EXISTS api_token VARCHAR NULL"); err != nil {
+			panic(err)
+		}
+		if _, err := GetDatabase().DB().Exec("CREATE UNIQUE INDEX IF NOT EXISTS users_api_token ON users(api_token) WHERE api_token IS NOT NULL"); err != nil {
+			panic(err)
+		}
+	}
 }
 
 func (r *UserRepository) Create(e *User) error {
@@ -197,10 +207,10 @@ func (r *UserRepository) Create(e *User) error {
 
 func (r *UserRepository) GetOne(id string) (*User, error) {
 	e := &User{}
-	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE id = $1",
-		id).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		id).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 	if err != nil {
 		return nil, err
 	}
@@ -209,10 +219,10 @@ func (r *UserRepository) GetOne(id string) (*User, error) {
 
 func (r *UserRepository) GetByEmail(organizationID string, email string) (*User, error) {
 	e := &User{}
-	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE LOWER(email) = $1 AND organization_id = $2",
-		strings.ToLower(email), organizationID).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		strings.ToLower(email), organizationID).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +231,7 @@ func (r *UserRepository) GetByEmail(organizationID string, email string) (*User,
 
 func (r *UserRepository) GetUsersWithEmail(email string) ([]*User, error) {
 	var result []*User
-	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE LOWER(email) = $1",
 		strings.ToLower(email))
@@ -231,7 +241,7 @@ func (r *UserRepository) GetUsersWithEmail(email string) ([]*User, error) {
 	defer rows.Close()
 	for rows.Next() {
 		e := &User{}
-		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 		if err != nil {
 			return nil, err
 		}
@@ -242,10 +252,10 @@ func (r *UserRepository) GetUsersWithEmail(email string) ([]*User, error) {
 
 func (r *UserRepository) GetByAtlassianID(atlassianID string) (*User, error) {
 	e := &User{}
-	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE LOWER(atlassian_id) = $1",
-		strings.ToLower(atlassianID)).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		strings.ToLower(atlassianID)).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +264,7 @@ func (r *UserRepository) GetByAtlassianID(atlassianID string) (*User, error) {
 
 func (r *UserRepository) GetUsersWithAtlassianID(organizationID string) ([]*User, error) {
 	var result []*User
-	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE organization_id = $1 AND (atlassian_id IS NOT NULL OR atlassian_id != '') "+
 		"ORDER BY email", organizationID)
@@ -264,7 +274,7 @@ func (r *UserRepository) GetUsersWithAtlassianID(organizationID string) ([]*User
 	defer rows.Close()
 	for rows.Next() {
 		e := &User{}
-		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 		if err != nil {
 			return nil, err
 		}
@@ -292,7 +302,7 @@ func (r *UserRepository) UpdateAtlassianClientID(organizationID, oldClientID, ne
 
 func (r *UserRepository) GetByKeyword(organizationID string, keyword string) ([]*User, error) {
 	var result []*User
-	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE organization_id = $1 AND (LOWER(email) LIKE '%' || $2 || '%' OR LOWER(firstname) LIKE '%' || $2 || '%' OR LOWER(lastname) LIKE '%' || $2 || '%') "+
 		"ORDER BY email", organizationID, strings.ToLower(keyword))
@@ -302,7 +312,7 @@ func (r *UserRepository) GetByKeyword(organizationID string, keyword string) ([]
 	defer rows.Close()
 	for rows.Next() {
 		e := &User{}
-		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 		if err != nil {
 			return nil, err
 		}
@@ -313,7 +323,7 @@ func (r *UserRepository) GetByKeyword(organizationID string, keyword string) ([]
 
 func (r *UserRepository) GetAll(organizationID string, maxResults int, offset int) ([]*User, error) {
 	var result []*User
-	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE organization_id = $1 "+
 		"ORDER BY email "+
@@ -324,7 +334,7 @@ func (r *UserRepository) GetAll(organizationID string, maxResults int, offset in
 	defer rows.Close()
 	for rows.Next() {
 		e := &User{}
-		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +345,7 @@ func (r *UserRepository) GetAll(organizationID string, maxResults int, offset in
 
 func (r *UserRepository) GetAllByIDs(userIDs []string) ([]*User, error) {
 	var result []*User
-	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required "+
+	rows, err := GetDatabase().DB().Query("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
 		"WHERE id = ANY($1) "+
 		"ORDER BY email",
@@ -346,7 +356,7 @@ func (r *UserRepository) GetAllByIDs(userIDs []string) ([]*User, error) {
 	defer rows.Close()
 	for rows.Next() {
 		e := &User{}
-		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired)
+		err = rows.Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 		if err != nil {
 			return nil, err
 		}
@@ -384,6 +394,24 @@ func (r *UserRepository) GetAllIDs() ([]string, error) {
 		result = append(result, ID)
 	}
 	return result, nil
+}
+
+func (r *UserRepository) GetByApiToken(tokenHash string) (*User, error) {
+	e := &User{}
+	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
+		"FROM users "+
+		"WHERE api_token = $1",
+		tokenHash).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
+	if err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+func (r *UserRepository) SetApiToken(userID string, tokenHash NullString) error {
+	_, err := GetDatabase().DB().Exec("UPDATE users SET api_token = $1 WHERE id = $2",
+		CheckNullString(tokenHash), userID)
+	return err
 }
 
 func (r *UserRepository) Update(e *User) error {

--- a/server/repository/user-repository.go
+++ b/server/repository/user-repository.go
@@ -400,8 +400,8 @@ func (r *UserRepository) GetByApiToken(tokenHash string) (*User, error) {
 	e := &User{}
 	err := GetDatabase().DB().QueryRow("SELECT id, organization_id, email, role, password, auth_provider_id, atlassian_id, disabled, ban_expiry, firstname, lastname, last_activity_at_utc, totp_secret, password_pending, password_update_required, api_token "+
 		"FROM users "+
-		"WHERE api_token = $1",
-		tokenHash).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
+		"WHERE api_token = $1 AND role IN ($2, $3)",
+		tokenHash, UserRoleServiceAccountRO, UserRoleServiceAccountRW).Scan(&e.ID, &e.OrganizationID, &e.Email, &e.Role, &e.HashedPassword, &e.AuthProviderID, &e.AtlassianID, &e.Disabled, &e.BanExpiry, &e.Firstname, &e.Lastname, &e.LastActivityAtUTC, &e.TotpSecret, &e.PasswordPending, &e.PasswordUpdateRequired, &e.ApiToken)
 	if err != nil {
 		return nil, err
 	}

--- a/server/router/routes.go
+++ b/server/router/routes.go
@@ -2,6 +2,8 @@ package router
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -294,35 +296,63 @@ func VerifyAuthMiddleware(next http.Handler) http.Handler {
 
 	var handleServiceAccountAuth = func(w http.ResponseWriter, r *http.Request) bool {
 		username, password, ok := r.BasicAuth()
-		if !ok {
+		if ok {
+			if len(username) < 36+2 && strings.Index(username, "_") != 36 {
+				return false
+			}
+			organizationId := username[:36]
+			email := username[37:]
+			user, err := GetUserRepository().GetByEmail(organizationId, email)
+			if err != nil || user == nil {
+				return false
+			}
+			if user.Role != UserRoleServiceAccountRO && user.Role != UserRoleServiceAccountRW {
+				return false
+			}
+			if user.HashedPassword == "" {
+				return false
+			}
+			if user.Disabled {
+				return false
+			}
+			if !GetUserRepository().CheckPassword(string(user.HashedPassword), password) {
+				return false
+			}
+			if r.Method != "GET" && user.Role == UserRoleServiceAccountRO {
+				return false
+			}
+			ctx := context.WithValue(r.Context(), contextKeyUserID, user.ID)
+			// Note: service accounts do not have sessions, so we do not set session ID in context
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return true
+		}
+
+		// Try Bearer token auth for service accounts
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
 			return false
 		}
-		if len(username) < 36+2 && strings.Index(username, "_") != 36 {
+		bearerValue := strings.TrimPrefix(authHeader, "Bearer ")
+		// JWTs start with "eyJ" — handled by handleTokenAuth, not here
+		if strings.HasPrefix(bearerValue, "eyJ") {
 			return false
 		}
-		organizationId := username[:36]
-		email := username[37:]
-		user, err := GetUserRepository().GetByEmail(organizationId, email)
+		hash := sha256.Sum256([]byte(bearerValue))
+		tokenHash := hex.EncodeToString(hash[:])
+		user, err := GetUserRepository().GetByApiToken(tokenHash)
 		if err != nil || user == nil {
 			return false
 		}
 		if user.Role != UserRoleServiceAccountRO && user.Role != UserRoleServiceAccountRW {
 			return false
 		}
-		if user.HashedPassword == "" {
-			return false
-		}
 		if user.Disabled {
-			return false
-		}
-		if !GetUserRepository().CheckPassword(string(user.HashedPassword), password) {
 			return false
 		}
 		if r.Method != "GET" && user.Role == UserRoleServiceAccountRO {
 			return false
 		}
 		ctx := context.WithValue(r.Context(), contextKeyUserID, user.ID)
-		// Note: service accounts do not have sessions, so we do not set session ID in context
 		next.ServeHTTP(w, r.WithContext(ctx))
 		return true
 	}

--- a/server/router/test/user-router_test.go
+++ b/server/router/test/user-router_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -835,4 +836,274 @@ func TestAllowRoleChangeForOtherUser(t *testing.T) {
 	var resBody *GetUserResponse
 	json.Unmarshal(res.Body.Bytes(), &resBody)
 	CheckTestInt(t, int(UserRoleSpaceAdmin), resBody.Role)
+}
+
+func TestApiTokenGenerate(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	admin := CreateTestUserOrgAdmin(org)
+	sa := CreateTestServiceAccountRW(org)
+
+	// POST generates token and returns it
+	req := NewHTTPRequest("POST", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+	var tokenResp GenerateApiTokenResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &tokenResp); err != nil {
+		t.Fatal(err)
+	}
+	if tokenResp.Token == "" {
+		t.Fatal("Expected non-empty token")
+	}
+
+	// GET shows configured: true
+	req = NewHTTPRequest("GET", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+	var statusResp GetApiTokenStatusResponse
+	json.Unmarshal(res.Body.Bytes(), &statusResp)
+	CheckTestBool(t, true, statusResp.Configured)
+}
+
+func TestApiTokenGenerateNonServiceAccount(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	admin := CreateTestUserOrgAdmin(org)
+	regularUser := CreateTestUserInOrg(org)
+
+	req := NewHTTPRequest("POST", "/user/"+regularUser.ID+"/api-token", admin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusBadRequest, res.Code)
+}
+
+func TestApiTokenGenerateForbidden(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := CreateTestServiceAccountRW(org)
+	nonAdmin := CreateTestUserInOrg(org)
+
+	req := NewHTTPRequest("POST", "/user/"+sa.ID+"/api-token", nonAdmin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusForbidden, res.Code)
+}
+
+func TestApiTokenGenerateOtherOrg(t *testing.T) {
+	ClearTestDB()
+	org1 := CreateTestOrg("org1.com")
+	org2 := CreateTestOrg("org2.com")
+	admin := CreateTestUserOrgAdmin(org1)
+	sa := CreateTestServiceAccountRW(org2)
+
+	req := NewHTTPRequest("POST", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusNotFound, res.Code)
+}
+
+func TestApiTokenRegenerate(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	admin := CreateTestUserOrgAdmin(org)
+	sa := CreateTestServiceAccountRW(org)
+
+	// Generate first token
+	req := NewHTTPRequest("POST", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+	var resp1 GenerateApiTokenResponse
+	json.Unmarshal(res.Body.Bytes(), &resp1)
+	oldToken := resp1.Token
+
+	// Generate second token
+	req = NewHTTPRequest("POST", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+	var resp2 GenerateApiTokenResponse
+	json.Unmarshal(res.Body.Bytes(), &resp2)
+	newToken := resp2.Token
+
+	if oldToken == newToken {
+		t.Fatal("Expected new token to differ from old token")
+	}
+
+	// Old token no longer authenticates
+	req = NewHTTPRequestBearer("GET", "/user/me", oldToken, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusUnauthorized, res.Code)
+
+	// New token authenticates
+	req = NewHTTPRequestBearer("GET", "/user/me", newToken, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+}
+
+func TestApiTokenRevoke(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	admin := CreateTestUserOrgAdmin(org)
+	sa := CreateTestServiceAccountRW(org)
+	token := GenerateTestApiToken(sa.ID)
+
+	// Verify configured first
+	req := NewHTTPRequest("GET", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+	var statusResp GetApiTokenStatusResponse
+	json.Unmarshal(res.Body.Bytes(), &statusResp)
+	CheckTestBool(t, true, statusResp.Configured)
+
+	// Revoke
+	req = NewHTTPRequest("DELETE", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusNoContent, res.Code)
+
+	// GET shows configured: false
+	req = NewHTTPRequest("GET", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+	var statusResp2 GetApiTokenStatusResponse
+	json.Unmarshal(res.Body.Bytes(), &statusResp2)
+	CheckTestBool(t, false, statusResp2.Configured)
+
+	// Token no longer works
+	req = NewHTTPRequestBearer("GET", "/user/me", token, nil)
+	res = ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestApiTokenRevokeNotFound(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	admin := CreateTestUserOrgAdmin(org)
+	sa := CreateTestServiceAccountRW(org)
+	// No token set — revoke is idempotent
+
+	req := NewHTTPRequest("DELETE", "/user/"+sa.ID+"/api-token", admin.ID, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusNoContent, res.Code)
+}
+
+func TestServiceAccountBearerAuth(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := CreateTestServiceAccountRW(org)
+	token := GenerateTestApiToken(sa.ID)
+
+	req := NewHTTPRequestBearer("GET", "/user/me", token, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+}
+
+func TestServiceAccountBearerAuthWrongToken(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := CreateTestServiceAccountRW(org)
+	GenerateTestApiToken(sa.ID)
+
+	req := NewHTTPRequestBearer("GET", "/user/me", "wrongtoken", nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestServiceAccountBearerAuthDisabledUser(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := CreateTestServiceAccountRW(org)
+	token := GenerateTestApiToken(sa.ID)
+
+	// Disable service account
+	sa.Disabled = true
+	if err := GetUserRepository().Update(sa); err != nil {
+		t.Fatal(err)
+	}
+
+	req := NewHTTPRequestBearer("GET", "/user/me", token, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestServiceAccountBearerAuthROReadRequest(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := &User{
+		Email:          uuid.New().String() + "@test.com",
+		OrganizationID: org.ID,
+		Role:           UserRoleServiceAccountRO,
+	}
+	if err := GetUserRepository().Create(sa); err != nil {
+		t.Fatal(err)
+	}
+	token := GenerateTestApiToken(sa.ID)
+
+	req := NewHTTPRequestBearer("GET", "/user/me", token, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+}
+
+func TestServiceAccountBearerAuthROWriteRequest(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := &User{
+		Email:          uuid.New().String() + "@test.com",
+		OrganizationID: org.ID,
+		Role:           UserRoleServiceAccountRO,
+	}
+	if err := GetUserRepository().Create(sa); err != nil {
+		t.Fatal(err)
+	}
+	token := GenerateTestApiToken(sa.ID)
+
+	req := NewHTTPRequestBearer("POST", "/user/", token, bytes.NewBufferString(`{"email":"x@y.com","firstname":"A","lastname":"B"}`))
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestServiceAccountBearerAuthRWWriteRequest(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	admin := CreateTestUserOrgAdmin(org)
+	sa := CreateTestServiceAccountRW(org)
+	token := GenerateTestApiToken(sa.ID)
+
+	// RW service account with Bearer token can make GET requests
+	req := NewHTTPRequestBearer("GET", "/user/"+admin.ID, token, nil)
+	res := ExecuteTestRequest(req)
+	// Service accounts cannot admin org, so this would be Forbidden, not Unauthorized
+	// What matters is that it's NOT 401 (which would indicate auth failure)
+	if res.Code == http.StatusUnauthorized {
+		t.Fatalf("Expected authenticated response (not 401), got %d", res.Code)
+	}
+}
+
+func TestServiceAccountBearerAuthJwtNotTreatedAsApiToken(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	user := CreateTestUserOrgAdmin(org)
+
+	// A valid JWT should be handled by handleTokenAuth, not misidentified as an API token
+	jwt := GetTestJWT(user.ID)
+	req := NewHTTPRequestBearer("GET", "/user/me", jwt, nil)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
+}
+
+func TestServiceAccountBasicAuthStillWorks(t *testing.T) {
+	ClearTestDB()
+	org := CreateTestOrg("test.com")
+	sa := &User{
+		Email:          uuid.New().String() + "@test.com",
+		OrganizationID: org.ID,
+		Role:           UserRoleServiceAccountRW,
+		HashedPassword: NullString(GetUserRepository().GetHashedPassword(TestPassword)),
+	}
+	if err := GetUserRepository().Create(sa); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build Basic Auth header: orgID_email:password
+	credentials := sa.OrganizationID + "_" + sa.Email + ":" + TestPassword
+	encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
+	req, _ := http.NewRequest("GET", "/user/me", nil)
+	req.Header.Set("Authorization", "Basic "+encoded)
+	res := ExecuteTestRequest(req)
+	CheckTestResponseCode(t, http.StatusOK, res.Code)
 }

--- a/server/router/user-router.go
+++ b/server/router/user-router.go
@@ -2,7 +2,10 @@ package router
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"image/png"
 	"log"
 	"net/http"
@@ -144,6 +147,9 @@ func (router *UserRouter) SetupRoutes(s *mux.Router) {
 	s.HandleFunc("/totp/disable", router.disableTotp).Methods("POST")
 	s.HandleFunc("/{id}/passkeys", router.adminResetPasskeys).Methods("DELETE")
 	s.HandleFunc("/{id}/totp", router.adminResetTotp).Methods("DELETE")
+	s.HandleFunc("/{id}/api-token", router.getApiToken).Methods("GET")
+	s.HandleFunc("/{id}/api-token", router.generateApiToken).Methods("POST")
+	s.HandleFunc("/{id}/api-token", router.revokeApiToken).Methods("DELETE")
 	s.HandleFunc("/merge/init", router.mergeInit).Methods("POST")
 	s.HandleFunc("/merge/finish/{id}", router.mergeFinish).Methods("POST")
 	s.HandleFunc("/merge", router.getMergeRequests).Methods("GET")
@@ -902,4 +908,106 @@ func (router *UserRouter) copyToRestModel(e *User, admin bool) *GetUserResponse 
 		m.AuthProviderID = string(e.AuthProviderID)
 	}
 	return m
+}
+
+type GenerateApiTokenResponse struct {
+	Token string `json:"token"`
+}
+
+type GetApiTokenStatusResponse struct {
+	Configured bool `json:"configured"`
+}
+
+func (router *UserRouter) getApiToken(w http.ResponseWriter, r *http.Request) {
+	user := GetRequestUser(r)
+	if !CanAdminOrg(user, user.OrganizationID) {
+		SendForbidden(w)
+		return
+	}
+	vars := mux.Vars(r)
+	e, err := GetUserRepository().GetOne(vars["id"])
+	if err != nil || e == nil {
+		SendNotFound(w)
+		return
+	}
+	if e.OrganizationID != user.OrganizationID && !GetUserRepository().IsSuperAdmin(user) {
+		SendNotFound(w)
+		return
+	}
+	if !isServiceAccountRole(int(e.Role)) {
+		SendBadRequest(w)
+		return
+	}
+	res := &GetApiTokenStatusResponse{
+		Configured: e.ApiToken != "",
+	}
+	SendJSON(w, res)
+}
+
+func (router *UserRouter) generateApiToken(w http.ResponseWriter, r *http.Request) {
+	user := GetRequestUser(r)
+	if !CanAdminOrg(user, user.OrganizationID) {
+		SendForbidden(w)
+		return
+	}
+	vars := mux.Vars(r)
+	e, err := GetUserRepository().GetOne(vars["id"])
+	if err != nil || e == nil {
+		SendNotFound(w)
+		return
+	}
+	if e.OrganizationID != user.OrganizationID && !GetUserRepository().IsSuperAdmin(user) {
+		SendNotFound(w)
+		return
+	}
+	if !isServiceAccountRole(int(e.Role)) {
+		SendBadRequest(w)
+		return
+	}
+	rawBytes := make([]byte, 32)
+	if _, err := rand.Read(rawBytes); err != nil {
+		log.Println(err)
+		SendInternalServerError(w)
+		return
+	}
+	rawToken := hex.EncodeToString(rawBytes)
+	hash := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(hash[:])
+	if err := GetUserRepository().SetApiToken(e.ID, NullString(tokenHash)); err != nil {
+		log.Println(err)
+		SendInternalServerError(w)
+		return
+	}
+	res := &GenerateApiTokenResponse{
+		Token: rawToken,
+	}
+	SendJSON(w, res)
+}
+
+func (router *UserRouter) revokeApiToken(w http.ResponseWriter, r *http.Request) {
+	user := GetRequestUser(r)
+	if !CanAdminOrg(user, user.OrganizationID) {
+		SendForbidden(w)
+		return
+	}
+	vars := mux.Vars(r)
+	e, err := GetUserRepository().GetOne(vars["id"])
+	if err != nil || e == nil {
+		SendNotFound(w)
+		return
+	}
+	if e.OrganizationID != user.OrganizationID && !GetUserRepository().IsSuperAdmin(user) {
+		SendNotFound(w)
+		return
+	}
+	if !isServiceAccountRole(int(e.Role)) {
+		SendBadRequest(w)
+		return
+	}
+	if err := GetUserRepository().SetApiToken(e.ID, NullString("")); err != nil {
+		log.Println(err)
+		SendInternalServerError(w)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/testutil/testutil.go
+++ b/server/testutil/testutil.go
@@ -1,6 +1,9 @@
 package testutil
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
+	. "github.com/seatsurfing/seatsurfing/server/api"
 	. "github.com/seatsurfing/seatsurfing/server/app"
 	. "github.com/seatsurfing/seatsurfing/server/config"
 	. "github.com/seatsurfing/seatsurfing/server/repository"
@@ -360,4 +364,38 @@ func TestRunner(m *testing.M) {
 	DropTestDB()
 	db.Close()
 	os.Exit(code)
+}
+
+func CreateTestServiceAccountRW(org *Organization) *User {
+	user := &User{
+		Email:          uuid.New().String() + "@test.com",
+		OrganizationID: org.ID,
+		Role:           UserRoleServiceAccountRW,
+	}
+	if err := GetUserRepository().Create(user); err != nil {
+		panic(err)
+	}
+	return user
+}
+
+func GenerateTestApiToken(userID string) string {
+	rawBytes := make([]byte, 32)
+	if _, err := rand.Read(rawBytes); err != nil {
+		panic(err)
+	}
+	rawToken := hex.EncodeToString(rawBytes)
+	hash := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(hash[:])
+	if err := GetUserRepository().SetApiToken(userID, NullString(tokenHash)); err != nil {
+		panic(err)
+	}
+	return rawToken
+}
+
+func NewHTTPRequestBearer(method, url, rawToken string, body io.Reader) *http.Request {
+	req, _ := http.NewRequest(method, url, body)
+	if rawToken != "" {
+		req.Header.Set("Authorization", "Bearer "+rawToken)
+	}
+	return req
 }

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -20,7 +20,7 @@ info:
 
     ## Authentication
 
-    Authentication is done via JWT Bearer tokens in the `Authorization` header. Service accounts may also use HTTP Basic Authentication.
+    Authentication is done via JWT Bearer tokens in the `Authorization` header. Service accounts may also use HTTP Basic Authentication (`Authorization: Basic <base64>`) or a long-lived API token (`Authorization: Bearer <token>`) generated via `POST /user/{id}/api-token`. API tokens are stored as SHA-256 hashes and are shown only once at generation time.
 
     ## Session management
 
@@ -101,6 +101,10 @@ components:
       type: http
       scheme: basic
       description: Service account authentication using `{orgId}_{email}` as username and the service account password
+    ServiceAccountBearerAuth:
+      type: http
+      scheme: bearer
+      description: Service account authentication using a long-lived API token generated via `POST /user/{id}/api-token`. The raw token is presented as a Bearer token. Read-only service accounts may only use this on `GET` requests.
 
   schemas:
     # --- Authentication ---
@@ -990,6 +994,21 @@ components:
         secret:
           type: string
           description: TOTP secret key for manual entry
+
+    GenerateApiTokenResponse:
+      type: object
+      properties:
+        token:
+          type: string
+          description: Raw API token (64-character lowercase hex string). Shown once only — store it securely.
+          example: "a3f1e2d4c5b6a7f8e9d0c1b2a3f4e5d6c7b8a9f0e1d2c3b4a5f6e7d8c9b0a1f2"
+
+    GetApiTokenStatusResponse:
+      type: object
+      properties:
+        configured:
+          type: boolean
+          description: Whether a long-lived API token is currently configured for this service account.
 
     ValidateTotpRequest:
       type: object
@@ -3888,6 +3907,93 @@ paths:
       responses:
         "204":
           $ref: "#/components/responses/Updated"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /user/{id}/api-token:
+    get:
+      tags: [Users]
+      summary: Get API token status
+      description: Returns whether a long-lived API token is currently configured for the specified service account. The raw token is never returned. Requires Org Admin role.
+      operationId: getApiTokenStatus
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Service account user ID
+      responses:
+        "200":
+          description: API token status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetApiTokenStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Users]
+      summary: Generate API token
+      description: |
+        Generates a new long-lived API token for the specified service account.
+        The raw token is returned **once** in the response and is not stored in plaintext.
+        Calling this endpoint again immediately invalidates the previous token.
+        The token can be used as `Authorization: Bearer <token>` on any endpoint that accepts service account credentials.
+        Requires Org Admin role.
+      operationId: generateApiToken
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Service account user ID
+      responses:
+        "200":
+          description: Generated API token (shown once only)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenerateApiTokenResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Users]
+      summary: Revoke API token
+      description: Revokes the API token for the specified service account. The token stops working immediately. This operation is idempotent (returns 204 even if no token was configured). Requires Org Admin role.
+      operationId: revokeApiToken
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Service account user ID
+      responses:
+        "204":
+          description: Token revoked (or was not set)
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":

--- a/specs/service-account-bearer-auth.md
+++ b/specs/service-account-bearer-auth.md
@@ -46,10 +46,10 @@ if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
 
 Service account roles:
 
-| Constant                | Value | Allowed methods |
-| ----------------------- | ----- | --------------- |
-| `UserRoleServiceAccountRO` | 21 | GET only        |
-| `UserRoleServiceAccountRW` | 22 | All methods     |
+| Constant                   | Value | Allowed methods |
+| -------------------------- | ----- | --------------- |
+| `UserRoleServiceAccountRO` | 21    | GET only        |
+| `UserRoleServiceAccountRW` | 22    | All methods     |
 
 The existing `isServiceAccountRole(role int) bool` helper in `user-router.go` identifies both.
 
@@ -75,6 +75,7 @@ This migration must be added to `server/repository/db-updates.go` under a new sc
 **`EncryptString`** (AES-256-GCM with a random nonce, used in this codebase for OAuth client secrets) is also ruled out. It has the same nonce-randomness problem as bcrypt: the same plaintext produces a different ciphertext on every call, so it cannot serve as an index key either. More importantly, `EncryptString` is reversible — it exists precisely so fields like client secrets can be recovered in plaintext when they must be forwarded to an external service. An API token is never recovered after initial issuance; the server only needs to answer "does the presented token match the stored value?" Storing a recoverable form of the token is a security regression: if both the database and the `CRYPT_KEY` config value are compromised, all tokens become usable by an attacker.
 
 **SHA-256** is correct here because:
+
 1. API tokens are server-generated 32-byte cryptographically random values (256 bits of entropy). Rainbow tables or brute-force are computationally infeasible regardless of hash algorithm.
 2. SHA-256 is deterministic, so `sha256hex(presentedToken)` can be compared against a single indexed column in O(1).
 3. A compromised database reveals only hashes. Without the original tokens (which only the token holders know), the hashes are useless to an attacker — no `CRYPT_KEY` is involved.
@@ -151,6 +152,7 @@ Generate a new API token for a service account user.
 **Request body**: none.
 
 **Behavior**:
+
 1. Load the target user. If not found or not in the caller's org → 404.
 2. If the target user's role is not `UserRoleServiceAccountRO` or `UserRoleServiceAccountRW` → 400 (only service accounts may have API tokens).
 3. Generate 32 cryptographically random bytes via `crypto/rand`. Encode as a 64-character lowercase hex string → `rawToken`.
@@ -175,6 +177,7 @@ Revoke the API token for a service account user.
 **Authorization**: Same as POST above.
 
 **Behavior**:
+
 1. Load the target user. If not found or not in caller's org → 404.
 2. If the target user is not a service account → 400.
 3. Set `users.api_token = NULL` for the target user.

--- a/specs/service-account-bearer-auth.md
+++ b/specs/service-account-bearer-auth.md
@@ -1,0 +1,261 @@
+# Feature Spec: Service Account Bearer Token Authentication
+
+## Overview
+
+Extend the existing service account authentication mechanism to support `Authorization: Bearer <token>` in addition to the existing `Authorization: Basic <base64>` (HTTP Basic Auth). This makes service accounts usable with clients and integrations that require or strongly prefer Bearer token authentication — most notably enterprise IdPs used with the SCIM server (see `specs/scim.md`), but also custom scripts and third-party tools that cannot easily construct Basic Auth headers.
+
+## Goals
+
+- Each service account user may optionally have a dedicated, long-lived API token.
+- The token can be presented as `Authorization: Bearer <token>` on any endpoint where the service account's Basic Auth credentials would currently be accepted.
+- The token is generated server-side with cryptographic randomness, returned once, and never retrievable in plaintext again.
+- Admins can generate and revoke API tokens for service accounts via the user management interface.
+- The existing HTTP Basic Auth mechanism is kept unchanged and continues to work alongside the new Bearer mechanism.
+- No changes to the RO/RW permission model: read-only service accounts may only use Bearer tokens on `GET` requests; read-write service accounts may use Bearer tokens on any method.
+
+## Non-Goals
+
+- Bearer token authentication for non-service-account users (regular users, org admins, super admins). They continue to use JWT-based sessions.
+- OAuth 2.0 client credential flows.
+- Token expiry or rotation schedules (the token is long-lived until explicitly revoked).
+- Multiple API tokens per service account in the first version.
+
+## Existing System Constraints
+
+### Service Account Authentication Today
+
+`VerifyAuthMiddleware` in `server/router/routes.go` runs on every request. For non-whitelisted routes it calls two handlers in order:
+
+```
+success := handleTokenAuth(w, r) || handleServiceAccountAuth(w, r)
+```
+
+`handleTokenAuth` parses a JWT from `Authorization: Bearer <jwt>`. If the value is not a valid JWT it returns `false`.
+
+`handleServiceAccountAuth` calls `r.BasicAuth()`. If the request carries `Authorization: Basic <base64>`, it decodes the credentials and looks up the service account. If the request carries a `Bearer` header (or no header), `r.BasicAuth()` returns `ok=false` and the function returns `false`.
+
+For whitelisted routes, the middleware additionally attempts both handlers when a `Bearer` header is present:
+
+```go
+if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
+    processedWithAuth = handleTokenAuth(w, r) || handleServiceAccountAuth(w, r)
+}
+```
+
+### User Roles
+
+Service account roles:
+
+| Constant                | Value | Allowed methods |
+| ----------------------- | ----- | --------------- |
+| `UserRoleServiceAccountRO` | 21 | GET only        |
+| `UserRoleServiceAccountRW` | 22 | All methods     |
+
+The existing `isServiceAccountRole(role int) bool` helper in `user-router.go` identifies both.
+
+## Data Model Changes
+
+### New Column: `users.api_token`
+
+Add a nullable `VARCHAR` column to the `users` table to hold the SHA-256 hex digest of the raw API token:
+
+```sql
+ALTER TABLE users ADD COLUMN IF NOT EXISTS api_token VARCHAR NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS users_api_token ON users(api_token) WHERE api_token IS NOT NULL;
+```
+
+The unique index enables O(1) lookup by token hash and prevents accidental collisions.
+
+This migration must be added to `server/repository/db-updates.go` under a new schema version number.
+
+### Why SHA-256, Not bcrypt or EncryptString
+
+**bcrypt** is ruled out for the same reason it is unsuitable for any lookup-keyed value: each invocation produces a different output (random salt), so the stored hash cannot be used as a database index key. Verifying a presented token would require decrypting or hashing every row in the table — O(n) work per request.
+
+**`EncryptString`** (AES-256-GCM with a random nonce, used in this codebase for OAuth client secrets) is also ruled out. It has the same nonce-randomness problem as bcrypt: the same plaintext produces a different ciphertext on every call, so it cannot serve as an index key either. More importantly, `EncryptString` is reversible — it exists precisely so fields like client secrets can be recovered in plaintext when they must be forwarded to an external service. An API token is never recovered after initial issuance; the server only needs to answer "does the presented token match the stored value?" Storing a recoverable form of the token is a security regression: if both the database and the `CRYPT_KEY` config value are compromised, all tokens become usable by an attacker.
+
+**SHA-256** is correct here because:
+1. API tokens are server-generated 32-byte cryptographically random values (256 bits of entropy). Rainbow tables or brute-force are computationally infeasible regardless of hash algorithm.
+2. SHA-256 is deterministic, so `sha256hex(presentedToken)` can be compared against a single indexed column in O(1).
+3. A compromised database reveals only hashes. Without the original tokens (which only the token holders know), the hashes are useless to an attacker — no `CRYPT_KEY` is involved.
+
+This is the same pattern used by GitHub personal access tokens, Gitea tokens, and similar systems. By contrast, passwords are stored with bcrypt because they are user-chosen with potentially low entropy, making a one-way-but-slow hash the correct defence.
+
+### Updated `User` Struct
+
+Add `ApiToken NullString` to `server/repository/user-repository.go`:
+
+```go
+type User struct {
+    // ... existing fields ...
+    ApiToken NullString  // SHA-256 hex digest; NULL when no token is configured
+}
+```
+
+Include `api_token` in all relevant `SELECT`, `INSERT`, and `UPDATE` statements in `UserRepository`.
+
+### New Repository Method
+
+Add to `UserRepository`:
+
+```go
+// GetByApiToken looks up a service account by its hashed API token.
+// Returns nil, nil when no matching user is found.
+func (r *UserRepository) GetByApiToken(tokenHash string) (*User, error)
+```
+
+Implementation: `SELECT ... FROM users WHERE api_token = $1`.
+
+## Authentication Flow Extension
+
+### Extended `handleServiceAccountAuth`
+
+`handleServiceAccountAuth` in `routes.go` is extended to try Bearer token auth after Basic Auth fails:
+
+```
+1. Try r.BasicAuth()
+   → If ok: validate credentials as before (unchanged behavior)
+
+2. If Basic Auth fails, inspect the Authorization header:
+   → If it doesn't start with "Bearer ": return false
+   → If the Bearer value starts with "eyJ": return false
+     (JWTs have the eyJ prefix; handleTokenAuth handles those)
+   → Compute SHA-256(bearerValue), call GetUserRepository().GetByApiToken(hash)
+   → If no user found: return false
+   → If user.Role not in {ServiceAccountRO, ServiceAccountRW}: return false
+   → If user.Disabled: return false
+   → If r.Method != "GET" and user.Role == UserRoleServiceAccountRO: return false
+   → Set user ID in request context, call next.ServeHTTP, return true
+```
+
+**No other code changes are needed in `routes.go`** because `handleServiceAccountAuth` is already called on both whitelisted and non-whitelisted routes when a Bearer header is present.
+
+### Interaction with `handleTokenAuth`
+
+`handleTokenAuth` is always tried first. For a non-JWT Bearer value it will fail silently (the JWT parser returns an error). `handleServiceAccountAuth` is then called and handles the API token. The order of operations is unchanged.
+
+### Interaction with Whitelisted Routes
+
+For paths in `unauthorizedRoutes` the middleware tries auth when a `Bearer` header is present (but does not reject the request if auth fails). This means service account Bearer tokens work on whitelisted routes too — the user context is populated if the token is valid, and the handler can gate behavior accordingly. The SCIM router relies on this behavior (see `specs/scim.md`).
+
+## API Endpoints
+
+These endpoints are added to `server/router/user-router.go`. Existing route registration in `SetupRoutes` is extended.
+
+### `POST /user/{id}/api-token`
+
+Generate a new API token for a service account user.
+
+**Authorization**: The calling user must be an org admin (`CanAdminOrg`) or super admin for the target user's organization. Service accounts cannot generate their own token.
+
+**Request body**: none.
+
+**Behavior**:
+1. Load the target user. If not found or not in the caller's org → 404.
+2. If the target user's role is not `UserRoleServiceAccountRO` or `UserRoleServiceAccountRW` → 400 (only service accounts may have API tokens).
+3. Generate 32 cryptographically random bytes via `crypto/rand`. Encode as a 64-character lowercase hex string → `rawToken`.
+4. Compute `sha256hex(rawToken)` → `tokenHash`.
+5. Store `tokenHash` in `users.api_token` for the target user (overwriting any existing token).
+6. Return HTTP 200 with body:
+
+```json
+{
+  "token": "<rawToken>"
+}
+```
+
+The raw token is returned exactly once. After this call completes, the plaintext is no longer accessible. The admin must copy it before navigating away.
+
+**Note**: Regenerating the token immediately invalidates the previous one. There is no separate "rotate" endpoint.
+
+### `DELETE /user/{id}/api-token`
+
+Revoke the API token for a service account user.
+
+**Authorization**: Same as POST above.
+
+**Behavior**:
+1. Load the target user. If not found or not in caller's org → 404.
+2. If the target user is not a service account → 400.
+3. Set `users.api_token = NULL` for the target user.
+4. Return HTTP 204.
+
+### `GET /user/{id}/api-token`
+
+Check whether the service account has a token configured.
+
+**Authorization**: Same as POST above.
+
+**Response**: HTTP 200 with body:
+
+```json
+{
+  "configured": true
+}
+```
+
+or `{"configured": false}` when no token is set. The raw token is never returned.
+
+## Admin UI Changes
+
+Extend the service account user detail view in the admin interface with a new **API Token** section, shown only when the selected user has a service account role:
+
+- `API Token` label with a status indicator: `Configured` (green) or `Not configured` (gray).
+- `Generate token` button: calls `POST /user/{id}/api-token`, shows the returned raw token in a modal with a copy-to-clipboard button and a warning that the token is shown only once.
+- `Revoke token` button (visible only when a token is configured): calls `DELETE /user/{id}/api-token` with a confirmation dialog.
+
+All controls are hidden when `feature_scim` is `false` if the only use-case is SCIM (revisit if Bearer auth is used for other purposes in the future).
+
+## Unit Tests
+
+Test file: `server/router/test/user-router_test.go` (extend existing file).
+
+### Helper Additions in testutil
+
+```go
+// CreateTestServiceAccountRW creates a RW service account in the given org.
+func CreateTestServiceAccountRW(org *Organization) *User
+
+// GenerateTestApiToken generates an API token for the given user and
+// stores the hash in the DB. Returns the raw token.
+func GenerateTestApiToken(userID string) string
+
+// NewHTTPRequestBearer wraps NewHTTPRequest but uses the provided raw token
+// as a Bearer token instead of a JWT.
+func NewHTTPRequestBearer(method, url, rawToken string, body io.Reader) *http.Request
+```
+
+### Required Test Cases
+
+#### Token Generation
+
+- `TestApiTokenGenerate` — POST by org admin on a service account returns 200 with a `token` field; subsequent `GET api-token` returns `configured: true`.
+- `TestApiTokenGenerateNonServiceAccount` — POST on a regular user → 400.
+- `TestApiTokenGenerateForbidden` — POST by a non-admin user → 403.
+- `TestApiTokenGenerateOtherOrg` — POST targeting a user in a different org → 404.
+- `TestApiTokenRegenerate` — POST twice; old token no longer authenticates; new token authenticates.
+
+#### Token Revocation
+
+- `TestApiTokenRevoke` — DELETE clears token; `GET api-token` returns `configured: false`.
+- `TestApiTokenRevokeNotFound` — DELETE on a user without a token → still 204 (idempotent).
+
+#### Bearer Authentication
+
+- `TestServiceAccountBearerAuth` — request with `Authorization: Bearer <validToken>` on a protected endpoint authenticates correctly and returns 200.
+- `TestServiceAccountBearerAuthWrongToken` — wrong token value → 401.
+- `TestServiceAccountBearerAuthDisabledUser` — service account is disabled → 401.
+- `TestServiceAccountBearerAuthROReadRequest` — RO account with Bearer token on GET → 200.
+- `TestServiceAccountBearerAuthROWriteRequest` — RO account with Bearer token on POST → 401.
+- `TestServiceAccountBearerAuthRWWriteRequest` — RW account with Bearer token on POST → 200 (or 201/204 depending on endpoint).
+- `TestServiceAccountBearerAuthJwtNotTreatedAsApiToken` — a valid JWT in the Bearer header is handled by `handleTokenAuth`, not misidentified as an API token.
+- `TestServiceAccountBasicAuthStillWorks` — existing Basic Auth service account requests continue to authenticate after the extension.
+
+## Migration Checklist
+
+1. `server/repository/db-updates.go` — add `api_token` column and unique index migration.
+2. `server/repository/user-repository.go` — add `ApiToken NullString` to `User` struct; add `GetByApiToken` method; include `api_token` in SELECT/INSERT/UPDATE queries.
+3. `server/router/routes.go` — extend `handleServiceAccountAuth` to handle non-JWT Bearer tokens via SHA-256 token hash lookup.
+4. `server/router/user-router.go` — add `POST`, `GET`, `DELETE /user/{id}/api-token` handlers and register routes in `SetupRoutes`.
+5. `server/router/test/user-router_test.go` — add test cases listed above.
+6. `server/testutil/testutil.go` — add `CreateTestServiceAccountRW`, `GenerateTestApiToken`, `NewHTTPRequestBearer` helpers.

--- a/ui/i18n/translations.de.json
+++ b/ui/i18n/translations.de.json
@@ -448,5 +448,12 @@
   "reportSettings": "Auswertungen",
   "statsHiddenByAdmin": "Die Auslastungsstatistiken wurden vom Administrator deaktiviert.",
   "workingHoursHintOnlyDaily": "Buchungen sind nur tageweise möglich.",
-  "workingHoursHintExceedsMaxDuration": "Die Bürozeiten überschreiten die maximale Buchungsdauer von {{num}} Stunden."
+  "workingHoursHintExceedsMaxDuration": "Die Bürozeiten überschreiten die maximale Buchungsdauer von {{num}} Stunden.",
+  "apiToken": "API-Token",
+  "apiTokenConfigured": "Konfiguriert",
+  "apiTokenNotConfigured": "Nicht konfiguriert",
+  "generateApiToken": "Token generieren",
+  "revokeApiToken": "Token widerrufen",
+  "apiTokenOnceWarning": "Kopieren Sie den Token jetzt – er wird nicht noch einmal angezeigt.",
+  "confirmRevokeApiToken": "API-Token widerrufen? Der Token wird sofort ungültig."
 }

--- a/ui/i18n/translations.en-GB.json
+++ b/ui/i18n/translations.en-GB.json
@@ -445,5 +445,12 @@
   "reportSettings": "Report settings",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.en-US.json
+++ b/ui/i18n/translations.en-US.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.es.json
+++ b/ui/i18n/translations.es.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.et.json
+++ b/ui/i18n/translations.et.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.fi.json
+++ b/ui/i18n/translations.fi.json
@@ -445,5 +445,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.fr.json
+++ b/ui/i18n/translations.fr.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.he.json
+++ b/ui/i18n/translations.he.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.hu.json
+++ b/ui/i18n/translations.hu.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.it.json
+++ b/ui/i18n/translations.it.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.nl.json
+++ b/ui/i18n/translations.nl.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.pl.json
+++ b/ui/i18n/translations.pl.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.pt.json
+++ b/ui/i18n/translations.pt.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.ro.json
+++ b/ui/i18n/translations.ro.json
@@ -447,5 +447,12 @@
   "hideStats": "Disable utilization statistics",
   "statsHiddenByAdmin": "Utilization statistics are disabled by your administrator.",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/i18n/translations.zh-TW.json
+++ b/ui/i18n/translations.zh-TW.json
@@ -445,5 +445,12 @@
   "reportSettings": "報告設定",
   "statsHiddenByAdmin": "使用率統計資料已被您的管理員停用。",
   "workingHoursHintOnlyDaily": "Bookings are only possible on a daily basis.",
-  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours."
+  "workingHoursHintExceedsMaxDuration": "The working hours exceeds max. booking duration of {{num}} hours.",
+  "apiToken": "API Token",
+  "apiTokenConfigured": "Configured",
+  "apiTokenNotConfigured": "Not configured",
+  "generateApiToken": "Generate token",
+  "revokeApiToken": "Revoke token",
+  "apiTokenOnceWarning": "Copy the token now — it will not be shown again.",
+  "confirmRevokeApiToken": "Revoke the API token? The token will stop working immediately."
 }

--- a/ui/src/pages/admin/users/[id].tsx
+++ b/ui/src/pages/admin/users/[id].tsx
@@ -1,5 +1,13 @@
 import React from "react";
-import { Form, Col, Row, Button, Alert, InputGroup } from "react-bootstrap";
+import {
+  Form,
+  Col,
+  Row,
+  Button,
+  Alert,
+  InputGroup,
+  Modal,
+} from "react-bootstrap";
 import {
   ChevronLeft as IconBack,
   Save as IconSave,
@@ -45,6 +53,9 @@ interface State {
   role: number;
   totpEnabled: boolean;
   hasPasskeys: boolean;
+  apiTokenConfigured: boolean;
+  showApiTokenModal: boolean;
+  generatedToken: string;
 }
 
 interface Props {
@@ -82,6 +93,9 @@ class EditUser extends React.Component<Props, State> {
       role: User.UserRoleUser,
       totpEnabled: false,
       hasPasskeys: false,
+      apiTokenConfigured: false,
+      showApiTokenModal: false,
+      generatedToken: "",
     };
   }
 
@@ -113,7 +127,7 @@ class EditUser extends React.Component<Props, State> {
     if (id && typeof id === "string" && id !== "add") {
       promises.push(User.get(id));
     }
-    Promise.all(promises).then((values) => {
+    Promise.all(promises).then(async (values) => {
       this.usersMax = values[0] === "1" ? 1000000 : 10;
       this.usersCur = values[1];
       this.adminUserRole = values[2][0].role;
@@ -130,6 +144,12 @@ class EditUser extends React.Component<Props, State> {
         } else if (user.requirePassword) {
           authMethod = "password";
         }
+        const isServiceAccount =
+          user.role === User.UserRoleServiceAccountRO ||
+          user.role === User.UserRoleServiceAccountRW;
+        const apiTokenConfigured = isServiceAccount
+          ? await User.getApiTokenStatus(user.id).catch(() => false)
+          : false;
         this.setState({
           email: user.email,
           originalEmail: user.email,
@@ -141,6 +161,7 @@ class EditUser extends React.Component<Props, State> {
           role: user.role,
           totpEnabled: user.totpEnabled,
           hasPasskeys: user.hasPasskeys,
+          apiTokenConfigured,
         });
       }
       this.setState({
@@ -244,6 +265,24 @@ class EditUser extends React.Component<Props, State> {
     this.setState({ role: role, changePassword });
     if (changePassword) {
       this.generatePassword();
+    }
+  };
+
+  generateApiToken = () => {
+    User.generateApiToken(this.entity.id).then((token) => {
+      this.setState({
+        apiTokenConfigured: true,
+        showApiTokenModal: true,
+        generatedToken: token,
+      });
+    });
+  };
+
+  revokeApiToken = () => {
+    if (window.confirm(this.props.t("confirmRevokeApiToken"))) {
+      User.revokeApiToken(this.entity.id).then(() => {
+        this.setState({ apiTokenConfigured: false });
+      });
     }
   };
 
@@ -701,7 +740,79 @@ class EditUser extends React.Component<Props, State> {
               )}
             </Col>
           </Form.Group>
+
+          {/* API Token section — only shown for existing service accounts */}
+          {this.entity.id && this.isServiceAccount(this.state.role) && (
+            <Form.Group as={Row}>
+              <Form.Label column sm="2">
+                {this.props.t("apiToken")}
+              </Form.Label>
+              <Col sm="4" className="d-flex gap-2 align-items-center">
+                <span
+                  className={
+                    this.state.apiTokenConfigured
+                      ? "text-success"
+                      : "text-secondary"
+                  }
+                >
+                  {this.state.apiTokenConfigured
+                    ? this.props.t("apiTokenConfigured")
+                    : this.props.t("apiTokenNotConfigured")}
+                </span>
+                <Button
+                  className="btn-sm"
+                  variant="outline-secondary"
+                  onClick={this.generateApiToken}
+                >
+                  {this.props.t("generateApiToken")}
+                </Button>
+                {this.state.apiTokenConfigured && (
+                  <Button
+                    className="btn-sm"
+                    variant="outline-danger"
+                    onClick={this.revokeApiToken}
+                  >
+                    {this.props.t("revokeApiToken")}
+                  </Button>
+                )}
+              </Col>
+            </Form.Group>
+          )}
         </Form>
+
+        <Modal
+          show={this.state.showApiTokenModal}
+          onHide={() =>
+            this.setState({ showApiTokenModal: false, generatedToken: "" })
+          }
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>{this.props.t("apiToken")}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Alert variant="warning">
+              {this.props.t("apiTokenOnceWarning")}
+            </Alert>
+            <InputGroup>
+              <Form.Control
+                type="text"
+                readOnly
+                value={this.state.generatedToken}
+              />
+              <CopyToClipboardButton text={this.state.generatedToken} />
+            </InputGroup>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              variant="secondary"
+              onClick={() =>
+                this.setState({ showApiTokenModal: false, generatedToken: "" })
+              }
+            >
+              {this.props.t("close")}
+            </Button>
+          </Modal.Footer>
+        </Modal>
       </FullLayout>
     );
   }

--- a/ui/src/types/User.ts
+++ b/ui/src/types/User.ts
@@ -227,6 +227,22 @@ export default class User extends Entity {
   static async adminResetTotp(userId: string): Promise<void> {
     return Ajax.delete("/user/" + userId + "/totp").then(() => undefined);
   }
+
+  static async getApiTokenStatus(userId: string): Promise<boolean> {
+    return Ajax.get("/user/" + userId + "/api-token").then(
+      (result) => result.json.configured as boolean,
+    );
+  }
+
+  static async generateApiToken(userId: string): Promise<string> {
+    return Ajax.postData("/user/" + userId + "/api-token", null).then(
+      (result) => result.json.token as string,
+    );
+  }
+
+  static async revokeApiToken(userId: string): Promise<void> {
+    return Ajax.delete("/user/" + userId + "/api-token").then(() => undefined);
+  }
 }
 
 export class TotpGenerateResponse {


### PR DESCRIPTION
This PR adds support for authenticating service accounts via Bearer Tokens in addition to the existing Basic Auth.

Admins can generate API Tokens for service accounts.

If an API Token is set, it can be used via the following HTTP Request Header:
```
Authorization: Bearer <API_TOKEN>
```