### PR TITLE
fix(server): use system dns instead of config nameserver when performing accessibility checks

### DIFF
--- a/server/util/domain-verification.go
+++ b/server/util/domain-verification.go
@@ -78,7 +78,7 @@ func isDomainAccessible(scheme, domain string, port int, orgID string) error {
 	if err != nil {
 		return err
 	}
-	client := GetHTTPClientWithCustomDNS(true)
+	client := GetHTTPClientInsecureSkipVerify()
 	res, err := client.Do(req)
 	if err != nil {
 		return err

--- a/server/util/netutil.go
+++ b/server/util/netutil.go
@@ -30,7 +30,9 @@ func GetHTTPClientWithCustomDNS(insecureSkipVerify bool) *http.Client {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return (&net.Dialer{
-				Resolver: GetDNSResolver(),
+				Resolver:  GetDNSResolver(),
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
 			}).DialContext(ctx, network, addr)
 		},
 	}
@@ -39,4 +41,24 @@ func GetHTTPClientWithCustomDNS(insecureSkipVerify bool) *http.Client {
 		Transport: tr,
 	}
 	return client
+}
+
+// GetHTTPClientInsecureSkipVerify returns an HTTP client that skips TLS
+// certificate verification but uses the system/cluster DNS resolver.
+// This is intentionally separate from GetHTTPClientWithCustomDNS: the custom
+// DNS resolver is appropriate for DNS lookups (e.g. TXT records) but not for
+// HTTP requests that must be routed through the cluster network (e.g. domain
+// accessibility checks via an ingress controller).
+func GetHTTPClientInsecureSkipVerify() *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	}
+	return &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: tr,
+	}
 }


### PR DESCRIPTION
`isDomainAccessible` was calling `GetHTTPClientWithCustomDNS(true)`, which always routes DNS through the configured DNSServer (e.g. an external resolver like 8.8.8.8). For TXT record lookups this is correct — you want to query an authoritative DNS. But for HTTP accessibility checks inside Kubernetes, that external DNS resolves the domain to its public/external IP, and the HTTP request to that address doesn't route back through HAProxy's internal ingress path → HAProxy returns 503.