### PR TITLE
feat(server): add DISABLE_VERSION_CHECK option

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -562,8 +562,12 @@ func (a *App) sendBookingReminderEmail(e *api.BookingDetails) {
 func (a *App) InitializeTimers() {
 	a.UpdateInstallStats()
 	a.onTimerTick()
-	installID, _ := GetSettingsRepository().GetGlobalString(api.SettingInstallID.Name)
-	go GetUpdateChecker().InitializeVersionUpdateTimer(installID)
+	if GetConfig().DisableVersionCheck {
+		log.Println("ℹ️  Version check is disabled.")
+	} else {
+		installID, _ := GetSettingsRepository().GetGlobalString(api.SettingInstallID.Name)
+		go GetUpdateChecker().InitializeVersionUpdateTimer(installID)
+	}
 	a.CleanupTicker = time.NewTicker(time.Minute * 1)
 	go func() {
 		for {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	MaxSessionsPerUser                  int    // Maximum number of concurrent sessions per user
 	WebAuthnRPDisplayName               string
 	MaxPasskeysPerUser                  int  // Maximum number of passkeys a single user may register
+	DisableVersionCheck                 bool // Disable polling seatsurfing.io for latest version information
 	DisableAnonymousUsageStats          bool // Disable sending anonymous usage statistics for this installation
 }
 
@@ -192,6 +193,7 @@ func (c *Config) ReadConfig() {
 		log.Println("⚠️  Warning: MAX_PASSKEYS_PER_USER must be at least 1. Defaulting to 10.")
 		c.MaxPasskeysPerUser = 10
 	}
+	c.DisableVersionCheck = (c.getEnv("DISABLE_VERSION_CHECK", "0") == "1")
 	c.DisableAnonymousUsageStats = (c.getEnv("DISABLE_ANONYMOUS_USAGE_STATS", "0") == "1")
 
 	// Check deprecated environment variables


### PR DESCRIPTION
Hey, i noticed that Seatsurfing always tries to reach `uc.seatsurfing.io` which is not always possible (e.g. air-gapped environment). 

This behavior produces the following log line:
```
Could not update latest version: Post "https://uc.seatsurfing.io/": Forbidden
```

So i thought it would be nice to disable that version check for installations that don't have access to the internet. 

I dont know how to add this change to the Docs as it seems like that repo isnt publicly available. 